### PR TITLE
refactor(install): replace nvm with mise for Node and Python version management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ docs/
 franklin/src/franklin_cli.egg-info/
 .ai-docs/
 
-# Node.js (for spec 006: NVM integration)
+# Node.js
 node_modules/
 npm-debug.log*
 yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ bash install.sh
 | Starship prompt | Configured via `starship.toml`; auto-enabled for a snappy shell. |
 | bat / batcat | Syntax-highlighted `cat` replacement; Franklin aliases `cat` ⇒ `bat`. |
 | fzf, ripgrep | Included on Linux for quick fuzzy search and grepping. |
-| NVM + Node LTS | Installed/pinned via `install.sh` & `update-all.sh`. |
+| mise + Node/Python LTS | Runtime versions managed via `mise.toml`; installed by `install.sh`. |
 | MOTD dashboard | Franklin Campfire banner with host/OS/disk/memory details. Toggle with `FRANKLIN_ENABLE_MOTD` / `FRANKLIN_SHOW_MOTD_ON_LOGIN`. |
 | Fonts | MOTD status icons (``, ``, turtle) require a Nerd Font (e.g., Dank Mono Nerd Font). |
 | Campfire UI palette | Non-banner UI chrome (install/update logs, badges) uses the Campfire palette (Cello/Terracotta/Black Rock) for consistent Franklin branding. |
@@ -60,7 +60,7 @@ Everything lives under your install dir (default `~/.local/share/franklin`) with
 
 | Command | Purpose |
 | --- | --- |
-| `update-all.sh` | Streams real-time progress while updating Franklin core files, OS packages (brew/apt/dnf), Sheldon plugins, Starship, Python, uv, NVM, Node, npm globals, and version pins. Detects your OS, filters noisy output in `auto` mode, and accepts `--mode=quiet|auto|verbose`. |
+| `update-all.sh` | Streams real-time progress while updating Franklin core files, OS packages (brew/apt/dnf), Sheldon plugins, Starship, mise runtimes (Node, Python), uv, npm globals, and version pins. Detects your OS, filters noisy output in `auto` mode, and accepts `--mode=quiet|auto|verbose`. |
 | `franklin` | Helper CLI wrapper; use `franklin update` for Franklin core only (via `update-franklin.sh`), `franklin update-all` for everything else, plus `franklin check`/`-v`. |
 | `motd` | Renders the Franklin dashboard on demand; auto-runs at login unless disabled. |
 | `reload` | Re-sources `.zshrc` after edits—Franklin's equivalent of poking his head out and checking his surroundings. |
@@ -151,4 +151,4 @@ MIT License. Check out the source at [github.com/jeremyfuksa/franklin](https://g
 Franklin stands on the shoulders of:
 - [Sheldon](https://github.com/rossmacarthur/sheldon) for plugin management
 - [Starship](https://github.com/starship/starship) for the prompt
-- [NVM](https://github.com/nvm-sh/nvm) for Node versioning
+- [mise](https://mise.jdx.dev) for Node and Python version management

--- a/franklin/config/mise.toml
+++ b/franklin/config/mise.toml
@@ -1,0 +1,7 @@
+# Franklin mise configuration
+# Manages Node.js and Python runtime versions
+# https://mise.jdx.dev
+
+[tools]
+node = "lts"
+python = "lts"

--- a/franklin/config/starship.toml
+++ b/franklin/config/starship.toml
@@ -79,7 +79,7 @@ symbol = "⬢ "
 style = "bold green"
 # Activate in common JS/TS/Bundler contexts so version shows reliably
 detect_extensions = ["js", "mjs", "cjs", "ts", "jsx", "tsx", "json", "vue", "svelte"]
-detect_files = ["package.json", "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb", ".node-version", ".nvmrc", "deno.json", "deno.jsonc"]
+detect_files = ["package.json", "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb", ".node-version", ".nvmrc", ".mise.toml", "deno.json", "deno.jsonc"]
 detect_folders = ["node_modules"]
 
 [rust]

--- a/franklin/src/install.sh
+++ b/franklin/src/install.sh
@@ -8,7 +8,7 @@
 # 2. Backs up existing Zsh configuration files
 # 3. Prompts for Campfire color selection (interactive mode)
 # 4. Installs dependencies via the appropriate package manager
-# 5. Sets up Sheldon, Starship, and NVM
+# 5. Sets up Sheldon, Starship, and mise
 # 6. Symlinks ~/.zshrc to the Franklin template
 # 7. Installs the Franklin CLI via Python
 #
@@ -314,18 +314,32 @@ fi
 ui_success "Dependencies installed"
 ui_section_end
 
-# --- Install NVM ---
-ui_header "Setting up NVM"
+# --- Install mise ---
+ui_header "Setting up mise"
 
-NVM_DIR="${HOME}/.nvm"
-if [ ! -d "$NVM_DIR" ]; then
-    ui_branch "Installing NVM..."
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash 2>&1 | sed 's/^/  /' >&2
+if ! command -v mise >/dev/null 2>&1; then
+    ui_branch "Installing mise..."
+    curl https://mise.run | sh 2>&1 | sed 's/^/  /' >&2
 else
-    ui_branch "NVM already installed"
+    ui_branch "mise already installed"
 fi
 
-ui_success "NVM ready"
+# Link mise config
+MISE_CONFIG_SRC="${FRANKLIN_ROOT}/config/mise.toml"
+MISE_CONFIG_LINK="${HOME}/.config/mise/config.toml"
+mkdir -p "$(dirname "$MISE_CONFIG_LINK")"
+if [ -f "$MISE_CONFIG_SRC" ]; then
+    ln -sf "$MISE_CONFIG_SRC" "$MISE_CONFIG_LINK"
+    ui_branch "Linked mise config"
+fi
+
+# Install managed runtimes (Node LTS + Python LTS)
+if command -v mise >/dev/null 2>&1; then
+    ui_branch "Installing runtimes via mise..."
+    mise install 2>&1 | sed 's/^/  /' >&2 || ui_warning "mise install had warnings (non-fatal)"
+fi
+
+ui_success "mise ready"
 ui_section_end
 
 # --- Set up Python Virtual Environment ---
@@ -374,9 +388,8 @@ if [ ! -f "$LOCAL_CONFIG_PATH" ]; then
 
 # PATH / Node / npm
 # -----------------
-# Example: pin a specific NVM-managed Node version on PATH at login.
-# Uncomment and adjust the version to match your system:
-# export PATH="$HOME/.nvm/versions/node/v18.18.0/bin:$PATH"
+# mise manages Node and Python versions globally via ~/.config/mise/config.toml.
+# To pin a project-local version, create a .mise.toml in the project directory.
 
 # MOTD (Message of the Day)
 # -------------------------

--- a/franklin/src/lib/main.py
+++ b/franklin/src/lib/main.py
@@ -427,7 +427,7 @@ def update_all(
     """
     Update Franklin core, plugins, and optionally system packages.
 
-    With --system: Updates OS packages, Sheldon plugins, Starship, NVM, and Node.
+    With --system: Updates OS packages, Sheldon plugins, Starship, mise runtimes, and Node.
     Without --system: Updates only Franklin core and Sheldon plugins.
     """
     ui.print_header("Franklin Update")

--- a/franklin/templates/zshrc.zsh
+++ b/franklin/templates/zshrc.zsh
@@ -30,38 +30,11 @@ _franklin_dedupe_path() {
     echo "$deduped_path"
 }
 
-# Resolve the NVM default alias to a concrete Node bin directory without fully loading nvm
-_franklin_nvm_default_bin() {
-    local nvm_dir="${NVM_DIR:-${HOME}/.nvm}"
-    local alias_path="${nvm_dir}/alias/default"
-    local target=""
-    local depth=0
-
-    # Preferred path: explicit default alias (or alias chain) pointing at a vX.Y.Z
-    if [[ -f "$alias_path" ]]; then
-        target="$(<"$alias_path")"
-        while (( depth < 3 )); do
-            if [[ "$target" == v* ]] && [[ -d "${nvm_dir}/versions/node/${target}/bin" ]]; then
-                echo "${nvm_dir}/versions/node/${target}/bin"
-                return
-            fi
-            if [[ -f "${nvm_dir}/alias/${target}" ]]; then
-                target="$(<"${nvm_dir}/alias/${target}")"
-                depth=$((depth + 1))
-                continue
-            fi
-            break
-        done
-    fi
-
-    # Fallback: if there is exactly one Node version installed under ~/.nvm, use it
-    if [[ -d "${nvm_dir}/versions/node" ]]; then
-        local -a bins
-        bins=(${nvm_dir}/versions/node/*/bin(N/))
-        if (( ${#bins[@]} == 1 )); then
-            echo "${bins[1]}"
-            return
-        fi
+# Resolve mise-managed shims directory for early PATH setup
+_franklin_mise_shims_bin() {
+    local shims_dir="${HOME}/.local/share/mise/shims"
+    if [[ -d "$shims_dir" ]]; then
+        echo "$shims_dir"
     fi
 }
 
@@ -75,9 +48,9 @@ _franklin_setup_path() {
         "${HOME}/.local/bin"
     )
 
-    local nvm_default_bin="$(_franklin_nvm_default_bin)"
-    if [[ -n "$nvm_default_bin" ]]; then
-        priority_dirs+=("$nvm_default_bin")
+    local mise_shims_bin="$(_franklin_mise_shims_bin)"
+    if [[ -n "$mise_shims_bin" ]]; then
+        priority_dirs+=("$mise_shims_bin")
     fi
 
     # Platform-specific directories
@@ -215,11 +188,11 @@ if command -v starship >/dev/null 2>&1; then
     eval "$(starship init zsh)"
 fi
 
-# --- NVM (Node Version Manager) ---
-# Load NVM if installed
-export NVM_DIR="${HOME}/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+# --- mise (Runtime Manager) ---
+# Activate mise for Node.js and Python version management
+if command -v mise >/dev/null 2>&1; then
+    eval "$(mise activate zsh)"
+fi
 
 # --- UV (Python Package Manager) ---
 # Ensure uv is on PATH if installed


### PR DESCRIPTION
## Changes

- **Replace NVM with mise**: Migrate from NVM to [mise](https://mise.jdx.dev) for managing Node.js and Python runtime versions
- **New mise configuration**: Add `franklin/config/mise.toml` to pin Node LTS and Python LTS versions
- **Update install script**: 
  - Install mise instead of NVM
  - Link mise config to `~/.config/mise/config.toml`
  - Run `mise install` to provision runtimes
  - Update example comments for project-level version pinning
- **Update zshrc template**: 
  - Remove NVM initialization and alias resolution logic
  - Replace with `mise activate zsh` for runtime management
  - Use mise shims directory in PATH setup
- **Update documentation**: 
  - README: Replace NVM references with mise throughout
  - Starship config: Add `.mise.toml` to Node detection files
  - Python CLI docstring: Update references from NVM to mise
- **Cleanup**: Simplify `.gitignore` comment for Node.js section

## Benefits

- Single tool for managing multiple runtime versions (Node, Python, etc.)
- Simpler configuration via TOML
- Project-level version pinning via `.mise.toml`
- Reduced shell initialization complexity