### PR TITLE
feat(install): add eza as a modern ls replacement (closes #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`eza` as a modern `ls` replacement** (closes #1). Installed via Homebrew (macOS), apt (Ubuntu 24.04+ / Debian 13+), and dnf (Fedora 38+); best-effort on older distros with a warning and graceful fallback. Zshrc aliases `ls`/`ll`/`la`/`lh`/`l` to eza equivalents with Git status + icons when eza is present, and preserves plain-`ls` behaviour when it isn't. New `lt` alias for a two-level tree view.
 - **Claude Code install option** in `install.sh` via `--with-claude` / `--no-claude` flags (interactive prompt by default on TTY; skipped in non-interactive mode unless `--with-claude` is passed). Uses Anthropic's native installer (`https://claude.ai/install.sh`) so no Node dependency is required.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ bash install.sh
 | Zsh + Sheldon | Franklin keeps a tidy `.zshrc` and installs anything missing. |
 | Starship prompt | Configured via `starship.toml`; auto-enabled for a snappy shell. |
 | bat / batcat | Syntax-highlighted `cat` replacement; Franklin aliases `cat` ⇒ `bat`. |
+| eza | Modern `ls` replacement with Git status, icons, and tree view. Franklin aliases `ls`/`ll`/`la`/`l` ⇒ `eza` when installed; adds `lt` for a quick tree. Falls back to plain `ls` on older distros where `eza` isn't packaged. |
 | fzf, ripgrep | Included on Linux for quick fuzzy search and grepping. |
 | mise + Node/Python LTS | Runtime versions managed via `mise.toml`; installed by `install.sh`. |
 | MOTD dashboard | Franklin Campfire banner with host/OS/disk/memory details. Toggle with `FRANKLIN_ENABLE_MOTD` / `FRANKLIN_SHOW_MOTD_ON_LOGIN`. |

--- a/franklin/src/install.sh
+++ b/franklin/src/install.sh
@@ -255,7 +255,7 @@ case "$OS_FAMILY" in
 
         # Install dependencies
         ui_branch "Installing packages via Homebrew..."
-        if ! brew install curl git zsh python3 bat sheldon starship 2>&1 | sed 's/^/      /' >&2; then
+        if ! brew install curl git zsh python3 bat eza sheldon starship 2>&1 | sed 's/^/      /' >&2; then
             ui_error_noexit "Some Homebrew packages failed to install"
             INSTALL_FAILED=true
         fi
@@ -289,6 +289,16 @@ case "$OS_FAMILY" in
                 INSTALL_FAILED=true
             fi
         fi
+
+        # Install eza (best-effort; only in apt on Ubuntu 24.04+ / Debian 13+)
+        if ! command -v eza >/dev/null 2>&1; then
+            ui_branch "Installing eza..."
+            if sudo apt-get install -y -qq eza 2>&1 | sed 's/^/      /' >&2; then
+                :
+            else
+                ui_warning "eza not available via apt on this release; ls aliases will fall back to plain ls (install manually from https://github.com/eza-community/eza to enable)"
+            fi
+        fi
         ;;
 
     fedora)
@@ -313,6 +323,16 @@ case "$OS_FAMILY" in
             if ! curl -fsSL https://starship.rs/install.sh | sh -s -- --yes 2>&1 | sed 's/^/      /' >&2; then
                 ui_error_noexit "Starship installation failed"
                 INSTALL_FAILED=true
+            fi
+        fi
+
+        # Install eza (best-effort; in dnf on Fedora 38+, may be absent on older RHEL-likes)
+        if ! command -v eza >/dev/null 2>&1; then
+            ui_branch "Installing eza..."
+            if sudo dnf install -y -q eza 2>&1 | sed 's/^/      /' >&2; then
+                :
+            else
+                ui_warning "eza not available via dnf on this release; ls aliases will fall back to plain ls (install manually from https://github.com/eza-community/eza to enable)"
             fi
         fi
         ;;

--- a/franklin/templates/zshrc.zsh
+++ b/franklin/templates/zshrc.zsh
@@ -127,6 +127,19 @@ alias la="ls -A"
 alias lh="ls -lh"
 alias l="ls -CF"
 
+# --- eza (enhanced ls) ---
+# If eza is installed, override the ls aliases above with eza equivalents.
+# Icons render correctly when a Nerd Font is active (Franklin's MOTD already
+# requires one); --icons=auto degrades gracefully on non-Nerd-Font terminals.
+if command -v eza >/dev/null 2>&1; then
+    alias ls="eza --group-directories-first --icons=auto"
+    alias ll="eza -l  --group-directories-first --icons=auto --git"
+    alias la="eza -la --group-directories-first --icons=auto --git"
+    alias lh="eza -lh --group-directories-first --icons=auto"
+    alias l="eza -CF  --group-directories-first --icons=auto"
+    alias lt="eza --tree --level=2 --icons=auto"
+fi
+
 # Navigation shortcuts
 alias ..="cd .."
 alias ...="cd ../.."


### PR DESCRIPTION
## Summary

Implements @heyitscosmin's suggestion in #1: add [`eza`](https://github.com/eza-community/eza) as a modern `ls` replacement with Git status, icons, and a tree view. Follows Franklin's existing pattern for `bat` (install the tool, alias the classic command).

- **macOS:** added to the `brew install` line alongside `bat`.
- **Debian/Ubuntu:** best-effort `apt-get install eza` as a separate step (only in apt on Ubuntu 24.04+ / Debian 13+; older releases get a clear warning instead of a hard failure).
- **Fedora/RHEL-likes:** best-effort `dnf install eza` (in Fedora 38+; older RHEL-likes get a warning).
- **zshrc template:** when `eza` is on `PATH`, overrides `ls`/`ll`/`la`/`lh`/`l` with eza equivalents (`--group-directories-first`, `--icons=auto`, `--git` for long views) and adds a new `lt` alias for a two-level tree. When eza isn't installed, the existing plain-`ls` aliases are unchanged — no regression for users on older distros.
- **README + CHANGELOG** updated.

## Design notes

- Aliases guarded by `command -v eza` so the zshrc degrades gracefully.
- `--icons=auto` lets eza pick based on terminal support. Franklin already requires a Nerd Font for the MOTD, so icons will render for most users; terminals without a Nerd Font just show glyphs-free rows.
- A failed eza install does **not** trip `INSTALL_FAILED`, since eza is strictly an enhancement, not a core dependency (matching the graceful-degradation philosophy of the project).

## Test plan

- [ ] macOS fresh install: verify `eza` installs via brew, `ls` + `ll` produce eza output with icons and Git status.
- [ ] Ubuntu 24.04 fresh install: verify apt installs eza, aliases active.
- [ ] Ubuntu 22.04 fresh install: verify apt gracefully warns, install completes, `ls` still works as plain ls.
- [ ] Fedora 39 fresh install: verify dnf installs eza, aliases active.
- [ ] Verify `lt` produces a two-level tree.
- [ ] Verify `ls` on a non-Nerd-Font terminal renders without broken glyphs (`--icons=auto` should handle this).

Closes #1.

https://claude.ai/code/session_01L6DH2fz6xtpoKMbvCK9Tks