### PR TITLE
feat(ui): expand Campfire palette to all 14 signature colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Expanded Campfire MOTD palette to 15 colors.** Previously the README advertised 14 Campfire signature names (`clay`, `ember`, `hay`, `moss`, `pine`, `dusk`, `mauve-earth`, `stone`, etc.) but the CLI only accepted 7 — selecting any of the other 8 via `franklin config --color ember` failed. Added `Clay`, `Ember`, `Hay`, `Moss`, `Pine`, `Dusk`, `Mauve Earth`, and `Stone` to `CAMPFIRE_COLORS`, each with `base`/`dark`/`light` variants derived from Campfire's signature palette (base = dark-mode swatch, light = light-mode swatch, dark = base darkened 18% in HSL to match the existing spread). `Black Rock` stays as an alias for `Stone` (same base hex) for backward compatibility.
+- **Case-insensitive / kebab-case color names.** `franklin config --color` and `install.sh --color` now accept `ember`, `Ember`, `EMBER`, `mauve-earth`, `Mauve_Earth`, `mauve earth`, etc. — anything that normalizes to a known palette key resolves to the canonical Title Case entry.
 - **`eza` as a modern `ls` replacement** (closes #1). Installed via Homebrew (macOS), apt (Ubuntu 24.04+ / Debian 13+), and dnf (Fedora 38+); best-effort on older distros with a warning and graceful fallback. Zshrc aliases `ls`/`ll`/`la`/`lh`/`l` to eza equivalents with Git status + icons when eza is present, and preserves plain-`ls` behaviour when it isn't. New `lt` alias for a two-level tree view.
 - **Claude Code install option** in `install.sh` via `--with-claude` / `--no-claude` flags (interactive prompt by default on TTY; skipped in non-interactive mode unless `--with-claude` is passed). Uses Anthropic's native installer (`https://claude.ai/install.sh`) so no Node dependency is required.
 

--- a/franklin/src/install.sh
+++ b/franklin/src/install.sh
@@ -129,38 +129,32 @@ ui_header "Configuring MOTD color"
 MOTD_COLOR="#607a97"  # Cello
 MOTD_COLOR_NAME="Cello"
 
-# Handle preset color from --color flag (case for Bash 3 / macOS compatibility)
+# Handle preset color from --color flag. Accepts Title Case ("Mauve Earth"),
+# lowercase ("mauve earth"), and kebab-case ("mauve-earth") forms for any
+# Campfire color name. Hex codes (#rrggbb) pass through as custom.
 if [ -n "$PRESET_COLOR" ]; then
-    case "$PRESET_COLOR" in
-        Cello)
-            MOTD_COLOR="#607a97"; MOTD_COLOR_NAME="Cello"
-            ui_success "Using preset color: $MOTD_COLOR_NAME ($MOTD_COLOR)"
-            ;;
-        Terracotta)
-            MOTD_COLOR="#b87b6a"; MOTD_COLOR_NAME="Terracotta"
-            ui_success "Using preset color: $MOTD_COLOR_NAME ($MOTD_COLOR)"
-            ;;
-        "Black Rock")
-            MOTD_COLOR="#747b8a"; MOTD_COLOR_NAME="Black Rock"
-            ui_success "Using preset color: $MOTD_COLOR_NAME ($MOTD_COLOR)"
-            ;;
-        Sage)
-            MOTD_COLOR="#8fb14b"; MOTD_COLOR_NAME="Sage"
-            ui_success "Using preset color: $MOTD_COLOR_NAME ($MOTD_COLOR)"
-            ;;
-        "Golden Amber")
-            MOTD_COLOR="#f9c574"; MOTD_COLOR_NAME="Golden Amber"
-            ui_success "Using preset color: $MOTD_COLOR_NAME ($MOTD_COLOR)"
-            ;;
-        Flamingo)
-            MOTD_COLOR="#e75351"; MOTD_COLOR_NAME="Flamingo"
-            ui_success "Using preset color: $MOTD_COLOR_NAME ($MOTD_COLOR)"
-            ;;
-        "Blue Calx")
-            MOTD_COLOR="#b8c5d9"; MOTD_COLOR_NAME="Blue Calx"
-            ui_success "Using preset color: $MOTD_COLOR_NAME ($MOTD_COLOR)"
-            ;;
+    # Normalize: lowercase, turn -/_ into spaces, collapse whitespace.
+    # Note: put '-' at the end of the tr set so it isn't parsed as a flag.
+    PRESET_COLOR_NORM="$(printf '%s' "$PRESET_COLOR" | tr '[:upper:]' '[:lower:]' | tr '_-' '  ' | xargs)"
+    PRESET_MATCHED=true
+    case "$PRESET_COLOR_NORM" in
+        cello)         MOTD_COLOR="#607a97"; MOTD_COLOR_NAME="Cello" ;;
+        terracotta)    MOTD_COLOR="#b87b6a"; MOTD_COLOR_NAME="Terracotta" ;;
+        "black rock")  MOTD_COLOR="#747b8a"; MOTD_COLOR_NAME="Black Rock" ;;
+        sage)          MOTD_COLOR="#8fb14b"; MOTD_COLOR_NAME="Sage" ;;
+        "golden amber") MOTD_COLOR="#f9c574"; MOTD_COLOR_NAME="Golden Amber" ;;
+        flamingo)      MOTD_COLOR="#e75351"; MOTD_COLOR_NAME="Flamingo" ;;
+        "blue calx")   MOTD_COLOR="#b8c5d9"; MOTD_COLOR_NAME="Blue Calx" ;;
+        clay)          MOTD_COLOR="#c89c8d"; MOTD_COLOR_NAME="Clay" ;;
+        ember)         MOTD_COLOR="#d97706"; MOTD_COLOR_NAME="Ember" ;;
+        hay)           MOTD_COLOR="#d4b86a"; MOTD_COLOR_NAME="Hay" ;;
+        moss)          MOTD_COLOR="#5a6f2d"; MOTD_COLOR_NAME="Moss" ;;
+        pine)          MOTD_COLOR="#4a7c7e"; MOTD_COLOR_NAME="Pine" ;;
+        dusk)          MOTD_COLOR="#8b7a9f"; MOTD_COLOR_NAME="Dusk" ;;
+        "mauve earth") MOTD_COLOR="#9b6b7f"; MOTD_COLOR_NAME="Mauve Earth" ;;
+        stone)         MOTD_COLOR="#747b8a"; MOTD_COLOR_NAME="Stone" ;;
         *)
+            PRESET_MATCHED=false
             if [[ "$PRESET_COLOR" =~ ^#[0-9A-Fa-f]{6}$ ]]; then
                 MOTD_COLOR="$PRESET_COLOR"
                 MOTD_COLOR_NAME="custom"
@@ -170,6 +164,9 @@ if [ -n "$PRESET_COLOR" ]; then
             fi
             ;;
     esac
+    if [ "$PRESET_MATCHED" = true ]; then
+        ui_success "Using preset color: $MOTD_COLOR_NAME ($MOTD_COLOR)"
+    fi
 # Interactive mode if TTY and not --non-interactive
 elif [ -t 0 ] && [ "$NON_INTERACTIVE" = false ]; then
     echo "" >&2

--- a/franklin/src/lib/constants.py
+++ b/franklin/src/lib/constants.py
@@ -51,6 +51,53 @@ CAMPFIRE_COLORS = {
         "dark": "#7b8da8",   # H: 218° L: 58% (shifts periwinkle, Δ-20%)
         "light": "#e5edf5",  # H: 206° L: 93% (shifts cyan-blue, Δ+15%)
     },
+    # --- Signature accent colors (from Campfire's signature palette) ---
+    # base  = Campfire dark-mode swatch (saturated, reads well on terminal bg)
+    # light = Campfire light-mode swatch (pastel)
+    # dark  = base darkened ~18% in HSL L (matches spread of entries above)
+    "Clay": {
+        "base":  "#c89c8d",
+        "dark":  "#a86751",
+        "light": "#e5beb0",
+    },
+    "Ember": {
+        "base":  "#d97706",
+        "dark":  "#804604",
+        "light": "#f5a855",
+    },
+    "Hay": {
+        "base":  "#d4b86a",
+        "dark":  "#b08f33",
+        "light": "#f2d88f",
+    },
+    "Moss": {
+        "base":  "#5a6f2d",
+        "dark":  "#252e13",
+        "light": "#88a055",
+    },
+    "Pine": {
+        "base":  "#4a7c7e",
+        "dark":  "#284344",
+        "light": "#75acaf",
+    },
+    "Dusk": {
+        "base":  "#8b7a9f",
+        "dark":  "#5d4f6e",
+        "light": "#b8a0cc",
+    },
+    "Mauve Earth": {
+        "base":  "#9b6b7f",
+        "dark":  "#664552",
+        "light": "#c898ad",
+    },
+    # Stone is Campfire's signature name for the same neutral gray-blue Franklin
+    # historically called "Black Rock". Both entries exist so legacy configs
+    # keep working; Stone is the canonical Campfire name going forward.
+    "Stone": {
+        "base":  "#747b8a",
+        "dark":  "#4a4f58",
+        "light": "#a0a8b5",
+    },
 }
 
 # Default color

--- a/franklin/src/lib/main.py
+++ b/franklin/src/lib/main.py
@@ -549,8 +549,16 @@ def config(
 
     # Flag-driven (non-interactive) path
     if color:
-        if color in CAMPFIRE_COLORS:
-            save_color(color, CAMPFIRE_COLORS[color]["base"])
+        # Accept canonical title-case ("Mauve Earth"), lowercase ("mauve earth"),
+        # and kebab-case ("mauve-earth") for any CAMPFIRE_COLORS key.
+        def _norm(name: str) -> str:
+            return name.lower().replace("-", " ").replace("_", " ").strip()
+
+        lookup = {_norm(k): k for k in CAMPFIRE_COLORS}
+        normalized = _norm(color)
+        if normalized in lookup:
+            canonical = lookup[normalized]
+            save_color(canonical, CAMPFIRE_COLORS[canonical]["base"])
             return
         import re
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -164,19 +164,42 @@ class TestConstants:
     def test_campfire_colors_has_expected_colors(self):
         """Test that CAMPFIRE_COLORS contains expected entries."""
         from lib.constants import CAMPFIRE_COLORS, DEFAULT_CAMPFIRE_COLOR
-        
+
         assert "Cello" in CAMPFIRE_COLORS
         assert "Terracotta" in CAMPFIRE_COLORS
         assert DEFAULT_CAMPFIRE_COLOR in CAMPFIRE_COLORS
 
+    def test_campfire_colors_includes_full_signature_palette(self):
+        """Every name advertised in the README must resolve in CAMPFIRE_COLORS."""
+        from lib.constants import CAMPFIRE_COLORS
+
+        signature_names = [
+            "Clay", "Flamingo", "Terracotta", "Ember", "Golden Amber", "Hay",
+            "Sage", "Moss", "Pine", "Cello", "Blue Calx", "Dusk",
+            "Mauve Earth", "Stone",
+        ]
+        for name in signature_names:
+            assert name in CAMPFIRE_COLORS, f"{name} missing from CAMPFIRE_COLORS"
+
     def test_campfire_colors_have_variants(self):
         """Test that each color has base/dark/light variants."""
         from lib.constants import CAMPFIRE_COLORS
-        
+
         for name, colors in CAMPFIRE_COLORS.items():
             assert "base" in colors, f"{name} missing 'base'"
             assert "dark" in colors, f"{name} missing 'dark'"
             assert "light" in colors, f"{name} missing 'light'"
+
+    def test_campfire_color_variants_are_valid_hex(self):
+        """Every base/dark/light value should be a 7-char #rrggbb string."""
+        import re
+        from lib.constants import CAMPFIRE_COLORS
+
+        hex_re = re.compile(r"^#[0-9a-fA-F]{6}$")
+        for name, colors in CAMPFIRE_COLORS.items():
+            for variant in ("base", "dark", "light"):
+                value = colors[variant]
+                assert hex_re.match(value), f"{name}.{variant}={value!r} is not valid hex"
 
     def test_glyphs_are_defined(self):
         """Test that all glyphs are defined."""


### PR DESCRIPTION
## Summary

Closes the long-standing gap between `README.md:34` (which advertises 14 Campfire signature color names: `clay, flamingo, terracotta, ember, golden-amber, hay, sage, moss, pine, cello, blue-calx, dusk, mauve-earth, stone`) and `CAMPFIRE_COLORS`, which only shipped 7. Today `franklin config --color ember` prints "Invalid color"; after this PR it works.

### Palette changes (`constants.py`)

Added 8 new entries sourced from the current Campfire signature palette in [`src/styles/globals.css`](https://github.com/jeremyfuksa/campfire/blob/main/src/styles/globals.css):

| Name | base | dark | light |
|------|------|------|-------|
| Clay | `#c89c8d` | `#a86751` | `#e5beb0` |
| Ember | `#d97706` | `#804604` | `#f5a855` |
| Hay | `#d4b86a` | `#b08f33` | `#f2d88f` |
| Moss | `#5a6f2d` | `#252e13` | `#88a055` |
| Pine | `#4a7c7e` | `#284344` | `#75acaf` |
| Dusk | `#8b7a9f` | `#5d4f6e` | `#b8a0cc` |
| Mauve Earth | `#9b6b7f` | `#664552` | `#c898ad` |
| Stone | `#747b8a` | `#4a4f58` | `#a0a8b5` |

- `base` = Campfire's dark-mode signature swatch (more saturated, reads well on terminal backgrounds).
- `light` = Campfire's light-mode signature swatch (already pastel).
- `dark` = `base` darkened by 18% in HSL lightness — matches the Δ-18 to -20% spread used by the existing 7 entries (computed with `colorsys`, not eyeballed).

**Stone / Black Rock note:** `Stone` and the pre-existing `Black Rock` share the same base hex (`#747b8a`) — they're the same neutral under two names. `Black Rock` stays in place so any user whose `config.env` has `MOTD_COLOR_NAME="Black Rock"` keeps working. `Stone` is the canonical Campfire name going forward.

### Name normalization (`main.py`, `install.sh`)

The README advertises names in kebab/lowercase (`mauve-earth`, `golden-amber`), but the dict keys are Title Case (`"Mauve Earth"`, `"Golden Amber"`). Before this PR the lookup was strict, so documented names failed.

- `franklin config --color` now normalizes input (lowercase, `-`/`_` → spaces, trim) before looking up, so `ember`, `Ember`, `EMBER`, `Mauve_Earth`, `mauve-earth` all resolve to the right canonical key.
- `install.sh --color NAME` applies the same normalization and has its `case` statement expanded to cover all 15 names. A `PRESET_MATCHED` flag prevents the invalid-input fall-through from falsely claiming "Using preset color…".

### Tests (`test_cli.py`)

- `test_campfire_colors_includes_full_signature_palette` asserts every name the README advertises is present.
- `test_campfire_color_variants_are_valid_hex` asserts every base/dark/light value is a real `#rrggbb` string (catches typos in palette data).

## Not in this PR (follow-up candidates)

- The interactive `install.sh` color picker still only shows 7 + custom. Users can pick the other 7 via `--color NAME` or post-install via `franklin config --color NAME`, but the TUI hasn't been expanded. Happy to follow up if you want a "more colors" submenu.
- Nord-ish UI chrome colors (`UI_ERROR_COLOR` et al. in `constants.py:61-64`) aren't touched here — that's opportunity **(3)** from the palette survey.
- Existing `Cello`/`Terracotta`/`Sage`/etc. still use handcrafted HSL shifts; Campfire now publishes curated 11-step scales that could replace them (opportunity **(2)**).

## Test plan

- [ ] `python -m pytest test/test_cli.py::TestConstants -v` — expect all assertions to pass.
- [ ] `franklin config --color ember` → config.env gets `MOTD_COLOR="#d97706"`, `MOTD_COLOR_NAME="Ember"`.
- [ ] `franklin config --color mauve-earth` → `MOTD_COLOR_NAME="Mauve Earth"`.
- [ ] `franklin config --color EMBER` → resolves case-insensitively.
- [ ] `bash franklin/src/install.sh --color pine --non-interactive` → picks Pine.
- [ ] `bash franklin/src/install.sh --color bogus --non-interactive` → warns and falls back to Cello (no false success).
- [ ] `franklin motd` → renders without errors for each new color.

https://claude.ai/code/session_01L6DH2fz6xtpoKMbvCK9Tks