### PR TITLE
refactor(ui): align Campfire palette with upstream semantic scales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Campfire palette aligned with upstream scales.** The 7 colors in `CAMPFIRE_COLORS` that correspond to Campfire semantic scales (Cello, Terracotta, Black Rock, Sage, Golden Amber, Flamingo, Blue Calx) now pull `dark`/`light` variants directly from Campfire's 11-step scales (`dark` = scale-700, `light` = scale-300, with Blue Calx using scale-100 since the info scale is compressed at the 300-500 end). Replaces hand-rolled HSL shifts, removes six stale "Δ-xx%" comments, and ensures the Franklin MOTD shares its hierarchy with the canonical Campfire design tokens. No user-visible config change is required — `MOTD_COLOR` / `MOTD_COLOR_NAME` keys continue to work.
+- **CLI chrome colors moved from Nord to Campfire semantics.** `UI_ERROR_COLOR`, `UI_SUCCESS_COLOR`, `UI_INFO_COLOR`, and `UI_WARNING_COLOR` in `constants.py` — plus their ANSI counterparts in `lib/ui.sh` — now map to Campfire's danger/success/primary/warning 500 values instead of Nord's red/green/blue/yellow. The result is that installer/update log chrome shares the same visual language as the MOTD banner. (Primary-500 is used for info since Campfire's info-500 is too pale to read as chrome on a terminal background.)
+
 ### Added
 
 - **Expanded Campfire MOTD palette to 15 colors.** Previously the README advertised 14 Campfire signature names (`clay`, `ember`, `hay`, `moss`, `pine`, `dusk`, `mauve-earth`, `stone`, etc.) but the CLI only accepted 7 — selecting any of the other 8 via `franklin config --color ember` failed. Added `Clay`, `Ember`, `Hay`, `Moss`, `Pine`, `Dusk`, `Mauve Earth`, and `Stone` to `CAMPFIRE_COLORS`, each with `base`/`dark`/`light` variants derived from Campfire's signature palette (base = dark-mode swatch, light = light-mode swatch, dark = base darkened 18% in HSL to match the existing spread). `Black Rock` stays as an alias for `Stone` (same base hex) for backward compatibility.

--- a/franklin/src/lib/constants.py
+++ b/franklin/src/lib/constants.py
@@ -13,43 +13,50 @@ CONFIG_FILE = CONFIG_DIR / "config.env"
 BACKUP_DIR = FRANKLIN_ROOT / "backups"
 
 # --- Campfire Color Palette (for MOTD) ---
-# These are the signature colors users can select for their MOTD banner
-# Each color has dark and light variants for visual hierarchy
+# These are the signature colors users can select for their MOTD banner.
+# Each color has base/dark/light variants for visual hierarchy.
+#
+# Colors with a Campfire semantic scale (primary/secondary/neutral/success/
+# warning/danger/info) use `base`=scale-500, `dark`=scale-700, `light`=scale-300.
+# (Blue Calx / info uses `light`=scale-100 because the info scale is unusually
+# compressed at the 300-500 end — scale-300 would be indistinguishable from
+# base.) The 8 signature-only accent colors use Campfire's dark-mode swatch as
+# base, its light-mode swatch as light, and a -18% HSL L shift for dark.
 CAMPFIRE_COLORS = {
     "Cello": {
-        "base": "#607a97",   # H: 210° L: 48% (blue-gray)
-        "dark": "#3d4f63",   # H: 213° L: 32% (shifts cooler/bluer, Δ-16%)
-        "light": "#a3bdd4",  # H: 207° L: 73% (shifts warmer/cyan, Δ+25%)
+        "base":  "#607a97",  # primary-500
+        "dark":  "#3e4f66",  # primary-700
+        "light": "#acbbcc",  # primary-300
     },
     "Terracotta": {
-        "base": "#b87b6a",   # H: 12° L: 57% (warm terracotta)
-        "dark": "#7a4a3e",   # H: 8° L: 38% (shifts toward brick red, Δ-19%)
-        "light": "#e8b5a5",  # H: 16° L: 77% (shifts peachy-pink, Δ+20%)
+        "base":  "#b87b6a",  # secondary-500
+        "dark":  "#8d5443",  # secondary-700
+        "light": "#dbbdb3",  # secondary-300
     },
     "Black Rock": {
-        "base": "#747b8a",   # H: 220° L: 51% (cool gray-blue)
-        "dark": "#494f5c",   # H: 225° L: 33% (shifts cooler/bluer, Δ-18%)
-        "light": "#a8b0be",  # H: 215° L: 71% (shifts warmer/steel, Δ+20%)
+        "base":  "#747b8a",  # neutral-500
+        "dark":  "#4d515c",  # neutral-700
+        "light": "#b8bcc5",  # neutral-300
     },
     "Sage": {
-        "base": "#8fb14b",   # H: 75° L: 50% (yellow-green)
-        "dark": "#5a6e2f",   # H: 72° L: 32% (shifts toward olive, Δ-18%)
-        "light": "#c5e088",  # H: 78° L: 73% (shifts toward lime, Δ+23%)
+        "base":  "#8fb14b",  # success-500
+        "dark":  "#5a6f2d",  # success-700
+        "light": "#b1d27e",  # success-300
     },
     "Golden Amber": {
-        "base": "#f9c574",   # H: 40° L: 72% (golden yellow)
-        "dark": "#b8873e",   # H: 35° L: 52% (shifts amber-orange, Δ-20%)
-        "light": "#ffe0b0",  # H: 45° L: 90% (shifts toward cream, Δ+18%)
+        "base":  "#f9c574",  # warning-500
+        "dark":  "#d97706",  # warning-700
+        "light": "#fddfa0",  # warning-300
     },
     "Flamingo": {
-        "base": "#e75351",   # H: 1° L: 60% (coral-red)
-        "dark": "#a12f2d",   # H: 0° L: 41% (shifts deep burgundy, Δ-19%)
-        "light": "#ff9d9b",  # H: 359° L: 80% (shifts pink-coral, Δ+20%)
+        "base":  "#e75351",  # danger-500
+        "dark":  "#be2b29",  # danger-700
+        "light": "#f8a5a4",  # danger-300
     },
     "Blue Calx": {
-        "base": "#b8c5d9",   # H: 212° L: 78% (powder blue)
-        "dark": "#7b8da8",   # H: 218° L: 58% (shifts periwinkle, Δ-20%)
-        "light": "#e5edf5",  # H: 206° L: 93% (shifts cyan-blue, Δ+15%)
+        "base":  "#b8c5d9",  # info-500
+        "dark":  "#8899b3",  # info-700
+        "light": "#e8eef6",  # info-100 (info scale is compressed; 300 ≈ base)
     },
     # --- Signature accent colors (from Campfire's signature palette) ---
     # base  = Campfire dark-mode swatch (saturated, reads well on terminal bg)
@@ -104,11 +111,12 @@ CAMPFIRE_COLORS = {
 DEFAULT_CAMPFIRE_COLOR = "Cello"
 
 # --- UI Chrome Colors (for CLI output, not MOTD) ---
-# These are used for the UI helpers in ui.py
-UI_ERROR_COLOR = "#bf616a"  # Red for errors
-UI_SUCCESS_COLOR = "#a3be8c"  # Green for success
-UI_INFO_COLOR = "#88c0d0"  # Blue for info
-UI_WARNING_COLOR = "#ebcb8b"  # Yellow for warnings
+# These are used for the UI helpers in ui.py. Aligned with Campfire's semantic
+# scales so install/update chrome shares the MOTD banner's visual language.
+UI_ERROR_COLOR = "#e75351"    # danger-500 (Flamingo family)
+UI_SUCCESS_COLOR = "#8fb14b"  # success-500 (Sage family)
+UI_INFO_COLOR = "#607a97"     # primary-500 (Cello family) — info-500 is too pale for chrome
+UI_WARNING_COLOR = "#f9c574"  # warning-500 (Golden Amber family)
 
 # --- Glyph Dictionary ---
 GLYPH_ACTION = "⏺"

--- a/franklin/src/lib/ui.sh
+++ b/franklin/src/lib/ui.sh
@@ -18,10 +18,11 @@ GLYPH_WARNING="⚠"
 GLYPH_ERROR="✗"
 
 # --- Colors (ANSI 24-bit) ---
-COLOR_ERROR="\033[38;2;191;97;106m"    # #bf616a
-COLOR_SUCCESS="\033[38;2;163;190;140m"  # #a3be8c
-COLOR_INFO="\033[38;2;136;192;208m"     # #88c0d0
-COLOR_WARNING="\033[38;2;235;203;139m"  # #ebcb8b
+# Aligned with Campfire semantic scales (mirrors UI_*_COLOR in constants.py).
+COLOR_ERROR="\033[38;2;231;83;81m"      # #e75351 (danger-500 / Flamingo family)
+COLOR_SUCCESS="\033[38;2;143;177;75m"   # #8fb14b (success-500 / Sage family)
+COLOR_INFO="\033[38;2;96;122;151m"      # #607a97 (primary-500 / Cello family)
+COLOR_WARNING="\033[38;2;249;197;116m"  # #f9c574 (warning-500 / Golden Amber family)
 COLOR_RESET="\033[0m"
 
 # --- TTY Detection ---


### PR DESCRIPTION
## Summary

Two cosmetic refinements that unify Franklin's visual language with the canonical Campfire design tokens published in [`jeremyfuksa/campfire`](https://github.com/jeremyfuksa/campfire). Follows up on opportunities **(2)** and **(3)** from the palette survey — opportunity (1) shipped in #5.

### 1. `CAMPFIRE_COLORS` variants pulled from Campfire's 11-step scales

The 7 colors that correspond to Campfire semantic scales now use curated scale values instead of hand-rolled HSL shifts:

| Franklin name | Scale family | base (500) | dark (700) | light |
|---|---|---|---|---|
| Cello | primary | `#607a97` | `#3e4f66` | `#acbbcc` (300) |
| Terracotta | secondary | `#b87b6a` | `#8d5443` | `#dbbdb3` (300) |
| Black Rock | neutral | `#747b8a` | `#4d515c` | `#b8bcc5` (300) |
| Sage | success | `#8fb14b` | `#5a6f2d` | `#b1d27e` (300) |
| Golden Amber | warning | `#f9c574` | `#d97706` | `#fddfa0` (300) |
| Flamingo | danger | `#e75351` | `#be2b29` | `#f8a5a4` (300) |
| Blue Calx | info | `#b8c5d9` | `#8899b3` | `#e8eef6` **(100)** |

**Blue Calx special case:** Campfire's info scale is compressed at the top end — info-300 (`#c6d3e4`) sits only 5% lightness away from info-500 (`#b8c5d9`) and would give no visible hierarchy. Using info-100 instead preserves the "light variant is clearly lighter than base" invariant.

**No migration required.** `base` hex values are unchanged, so any `config.env` with `MOTD_COLOR_NAME="Cello"` / `MOTD_COLOR="#607a97"` keeps working. Only the `dark` and `light` variants shift (typically by ~5-15 hex points), which affects MOTD internal hierarchy but not the user's selected banner color.

Six stale `# H: xx° L: yy% Δ-zz%` comments that were hand-computed HSL math are removed — they weren't going to stay accurate if the base ever changed, and Campfire's scales are the source of truth now.

### 2. UI chrome swapped from Nord to Campfire semantics

`constants.py` `UI_ERROR_COLOR` / `UI_SUCCESS_COLOR` / `UI_INFO_COLOR` / `UI_WARNING_COLOR` and their ANSI 24-bit counterparts in `lib/ui.sh` moved off the old Nord palette:

| Use | Old (Nord) | New (Campfire) |
|---|---|---|
| Error | `#bf616a` | `#e75351` — danger-500 (Flamingo) |
| Success | `#a3be8c` | `#8fb14b` — success-500 (Sage) |
| Info | `#88c0d0` | `#607a97` — primary-500 (Cello) ⁎ |
| Warning | `#ebcb8b` | `#f9c574` — warning-500 (Golden Amber) |

⁎ **Info uses primary-500 rather than info-500** because info-500 (`#b8c5d9`) is deliberately pale — it's meant as a background accent in the Campfire web context. For CLI chrome it's too low-contrast on most terminal backgrounds, so I fell back to primary-500 (Cello), which is Franklin's canonical "blue" anyway.

The effect is that installer/update log badges, warning bubbles, and error messages now share the MOTD banner's palette instead of visually belonging to a separate (Nord) theme.

## Test plan

- [ ] `python -m pytest test/test_cli.py -v` — existing palette assertions should still pass (every base/dark/light is valid hex; all 14 signature names present).
- [ ] `franklin motd` renders cleanly with each semantic color — dark and light variants should be visibly distinct, especially Blue Calx which now uses scale-100 light.
- [ ] `franklin config --color cello` then `franklin motd` — banner hierarchy still reads correctly.
- [ ] Run `bash franklin/src/install.sh --non-interactive --color cello` in a throwaway environment; verify error/warning/success badges render in the new Campfire colors (not Nord).

https://claude.ai/code/session_01L6DH2fz6xtpoKMbvCK9Tks