### PR TITLE
fix(bootstrap): auto-install missing prerequisites (git/curl/python3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`bootstrap.sh` auto-installs missing prerequisites.** Previously, on a fresh machine without `git` (or `curl` / `python3`), the bootstrapper would print `✗ git is required but not found` and bail out, leaving the user to go install the tool by hand before retrying. Bootstrap now detects the platform manager (`brew` on macOS, `apt-get` or `dnf` on Linux) and installs missing prerequisites automatically. On Debian/Ubuntu it also pulls `python3-venv` if the `venv` module isn't importable, so `install.sh` can create its virtual environment later. macOS systems without Homebrew get a clear message with both `xcode-select --install` and the Homebrew URL.
+
 ## [2.1.0] - 2026-04-17
 
 ### Changed

--- a/franklin/src/bootstrap.sh
+++ b/franklin/src/bootstrap.sh
@@ -94,16 +94,77 @@ case "$OS" in
         ;;
 esac
 
-# Check for required commands
-for cmd in git curl; do
-    if ! command -v "$cmd" >/dev/null 2>&1; then
-        ui_error "$cmd is required but not found. Please install it and try again."
-    fi
-done
+# --- Auto-install helper ---
+# Attempts to install a missing package via the detected platform's package
+# manager. On macOS, requires Homebrew (and guides toward xcode-select if
+# absent). On Linux, uses apt-get or dnf. Any failure is reported but passed
+# back to the caller via non-zero return so the preflight loop can decide.
+_bootstrap_install_pkg() {
+    local pkg="$1"
+    case "$OS" in
+        Darwin)
+            if command -v brew >/dev/null 2>&1; then
+                ui_branch "Installing $pkg via Homebrew..."
+                brew install "$pkg" 2>&1 | sed 's/^/    /' >&2
+                return $?
+            else
+                ui_branch "Homebrew not found. Franklin needs one of:"
+                ui_branch "  - Xcode Command Line Tools: xcode-select --install  (provides git + curl)"
+                ui_branch "  - Homebrew:                 https://brew.sh"
+                return 1
+            fi
+            ;;
+        Linux)
+            if command -v apt-get >/dev/null 2>&1; then
+                ui_branch "Installing $pkg via apt..."
+                sudo apt-get update -qq 2>&1 | sed 's/^/    /' >&2
+                sudo apt-get install -y -qq "$pkg" 2>&1 | sed 's/^/    /' >&2
+                return $?
+            elif command -v dnf >/dev/null 2>&1; then
+                ui_branch "Installing $pkg via dnf..."
+                sudo dnf install -y -q "$pkg" 2>&1 | sed 's/^/    /' >&2
+                return $?
+            else
+                ui_branch "No supported package manager found (apt-get / dnf)."
+                return 1
+            fi
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
 
-# Check for Python 3
-if ! command -v python3 >/dev/null 2>&1; then
-    ui_error "Python 3 is required but not found. Please install Python 3 and try again."
+# Check for required commands; auto-install if missing. On Debian/Ubuntu
+# python3 also needs the python3-venv package so install.sh can create the
+# Franklin venv later.
+_bootstrap_ensure() {
+    local cmd="$1"
+    local pkg="${2:-$1}"
+    if command -v "$cmd" >/dev/null 2>&1; then
+        return 0
+    fi
+    ui_branch "$cmd not found; attempting auto-install..."
+    if _bootstrap_install_pkg "$pkg" && command -v "$cmd" >/dev/null 2>&1; then
+        ui_branch "$cmd installed"
+        return 0
+    fi
+    ui_error "Failed to install $cmd automatically. Please install it manually and rerun."
+}
+
+_bootstrap_ensure git
+_bootstrap_ensure curl
+_bootstrap_ensure python3
+
+# Debian/Ubuntu ships `python3-venv` separately from `python3`; install.sh
+# will need it. Best-effort: if apt is available and the venv module isn't
+# importable, pull python3-venv in.
+if [ "$OS" = "Linux" ] && command -v apt-get >/dev/null 2>&1; then
+    if ! python3 -c "import venv" >/dev/null 2>&1; then
+        ui_branch "python3-venv module not available; installing..."
+        sudo apt-get install -y -qq python3-venv 2>&1 | sed 's/^/    /' >&2 || \
+            ui_branch "Could not install python3-venv; install.sh may need to do it later."
+    fi
 fi
 
 ui_success "Pre-flight checks passed"


### PR DESCRIPTION
## Summary

Fixes the "first install on a truly fresh machine" failure mode you hit:

```
⎿  ✗ git is required but not found. Please install it and try again.
```

Before this PR, `bootstrap.sh` checked for `git`, `curl`, and `python3` and bailed if any were missing — making the user go chase the tool manually before they could even start. Now the bootstrapper detects the platform's package manager and installs missing prerequisites itself.

## Behavior

| Platform | Manager | Command used |
|---|---|---|
| macOS + Homebrew | `brew` | `brew install <pkg>` |
| macOS without Homebrew | — | Clear error pointing at both `xcode-select --install` and https://brew.sh |
| Debian/Ubuntu | `apt-get` | `sudo apt-get update && sudo apt-get install -y <pkg>` |
| Fedora/RHEL | `dnf` | `sudo dnf install -y <pkg>` |
| Anything else | — | Same hard-fail as before, but only as a last resort |

On **Debian/Ubuntu** the bootstrap also pulls `python3-venv` whenever `python3 -c "import venv"` fails, since `install.sh` needs it later to create the Franklin virtualenv and Debian splits that module into its own package.

## Design notes

- Kept `set -e` behaviour: if auto-install itself errors out, `ui_error` fires with actionable guidance rather than silently continuing into a broken install.
- Uses `sudo` on Linux. The bootstrapper already assumed sudo would be available (install.sh has been calling `sudo apt-get` / `sudo dnf` all along); this just surfaces the prompt earlier. If the user is running via `curl | bash` without a TTY, sudo will prompt through stdin — which is already how install.sh works.
- macOS without Homebrew intentionally errors rather than auto-installing brew. Installing Homebrew is a big, opinionated side-effect; `xcode-select --install` (which ships a usable `git` + `curl`) is often the user's preferred path.

## Test plan

- [ ] On a fresh Debian/Ubuntu VM with `git` purged, run the curl-pipe bootstrap and verify `git` installs automatically and the flow proceeds to `install.sh`.
- [ ] On a fresh Fedora VM with `git` missing, verify dnf path works.
- [ ] On macOS with Homebrew, temporarily rename `git` and verify `brew install git` is invoked.
- [ ] On macOS without Homebrew, verify the error message mentions both `xcode-select --install` and https://brew.sh.
- [ ] On a distro with neither `apt-get` nor `dnf`, verify the bootstrap still errors clearly (not a silent no-op).
- [ ] With `sudo` credentials not cached, verify the prompt appears and input works via the existing stdin.

https://claude.ai/code/session_01L6DH2fz6xtpoKMbvCK9Tks