### PR TITLE
fix(install): make zsh the default login shell (chsh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`install.sh` now actually makes zsh the default login shell.** This was a long-standing bug: the installer symlinked `.zshrc` and printed `Restart your shell or run: exec zsh` in the post-install steps but never ran `chsh`, so users logging back in via SSH would land in bash (which doesn't source `.zshrc`) and see none of their Franklin setup. The installer now ensures `zsh` is registered in `/etc/shells`, runs `chsh -s $(command -v zsh)` for the current user (reading the password prompt from `/dev/tty` so it works under `curl | bash` too), and reports whether the change succeeded. Opt out with the new `--no-chsh` flag.
 - **`bootstrap.sh` auto-installs missing prerequisites.** Previously, on a fresh machine without `git` (or `curl` / `python3`), the bootstrapper would print `✗ git is required but not found` and bail out, leaving the user to go install the tool by hand before retrying. Bootstrap now detects the platform manager (`brew` on macOS, `apt-get` or `dnf` on Linux) and installs missing prerequisites automatically. On Debian/Ubuntu it also pulls `python3-venv` if the `venv` module isn't importable, so `install.sh` can create its virtual environment later. macOS systems without Homebrew get a clear message with both `xcode-select --install` and the Homebrew URL.
 
 ## [2.1.0] - 2026-04-17

--- a/franklin/src/install.sh
+++ b/franklin/src/install.sh
@@ -17,6 +17,7 @@
 #   --color NAME        Pre-select MOTD color (e.g., Cello, Terracotta)
 #   --with-claude       Install Claude Code (native installer) without prompting
 #   --no-claude         Skip Claude Code installation without prompting
+#   --no-chsh           Don't change the user's default login shell to zsh
 
 set -euo pipefail
 
@@ -31,6 +32,7 @@ VENV_DIR="${HOME}/.local/share/franklin/venv"
 NON_INTERACTIVE=false
 PRESET_COLOR=""
 CLAUDE_CHOICE=""  # "", "yes", or "no"
+CHSH_ENABLED=true
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -54,9 +56,13 @@ while [ $# -gt 0 ]; do
             CLAUDE_CHOICE="no"
             shift
             ;;
+        --no-chsh)
+            CHSH_ENABLED=false
+            shift
+            ;;
         *)
             echo "ERROR: Unknown argument: $1" >&2
-            echo "Usage: install.sh [--non-interactive] [--color NAME] [--with-claude|--no-claude]" >&2
+            echo "Usage: install.sh [--non-interactive] [--color NAME] [--with-claude|--no-claude] [--no-chsh]" >&2
             exit 1
             ;;
     esac
@@ -539,14 +545,84 @@ ln -sf "${FRANKLIN_ROOT}/config/starship.toml" "$STARSHIP_CONFIG"
 ui_success "Starship config linked"
 ui_section_end
 
+# --- Set zsh as the default login shell ---
+# Without this, SSH sessions and new terminals will still land in whatever
+# shell was the default (bash on most Linux distros), meaning the Franklin
+# .zshrc never gets sourced. Opt out with --no-chsh.
+ui_header "Setting zsh as the default login shell"
+
+CHSH_CHANGED=false
+CHSH_SKIPPED_REASON=""
+
+_install_ensure_zsh_in_shells() {
+    local zsh_path="$1"
+    # /etc/shells exists on every supported OS; if the path is already there
+    # we don't need sudo.
+    if [ -f /etc/shells ] && grep -Fxq "$zsh_path" /etc/shells; then
+        return 0
+    fi
+    ui_branch "Registering $zsh_path in /etc/shells..."
+    if echo "$zsh_path" | sudo tee -a /etc/shells >/dev/null 2>&1; then
+        return 0
+    fi
+    return 1
+}
+
+if [ "$CHSH_ENABLED" != true ]; then
+    CHSH_SKIPPED_REASON="--no-chsh flag was passed"
+elif ! command -v zsh >/dev/null 2>&1; then
+    CHSH_SKIPPED_REASON="zsh is not on PATH (dependency install may have failed)"
+elif ! command -v chsh >/dev/null 2>&1; then
+    CHSH_SKIPPED_REASON="chsh is not available on this system"
+else
+    ZSH_PATH="$(command -v zsh)"
+    CURRENT_SHELL="${SHELL:-}"
+
+    if [ "$CURRENT_SHELL" = "$ZSH_PATH" ]; then
+        ui_branch "zsh is already the default shell ($ZSH_PATH)"
+    else
+        if _install_ensure_zsh_in_shells "$ZSH_PATH"; then
+            # chsh prompts for the user's password via PAM. When install.sh
+            # is launched through `curl | bash`, stdin is the pipe so the
+            # prompt can't read; redirecting from /dev/tty works around that
+            # in interactive SSH / terminal sessions. If /dev/tty isn't
+            # available (cron, systemd unit, etc.), skip.
+            if [ ! -c /dev/tty ]; then
+                CHSH_SKIPPED_REASON="no controlling TTY for chsh password prompt"
+            else
+                ui_branch "Changing default shell to $ZSH_PATH..."
+                if chsh -s "$ZSH_PATH" </dev/tty 2>&1 | sed 's/^/      /' >&2; then
+                    CHSH_CHANGED=true
+                else
+                    ui_warning "chsh failed. You can finish the change manually: chsh -s $ZSH_PATH"
+                    CHSH_SKIPPED_REASON="chsh invocation failed"
+                fi
+            fi
+        else
+            ui_warning "Could not register $ZSH_PATH in /etc/shells (sudo prompt may have been declined)"
+            CHSH_SKIPPED_REASON="zsh is not in /etc/shells"
+        fi
+    fi
+fi
+
+if [ "$CHSH_CHANGED" = true ]; then
+    ui_success "Default shell set to zsh (log out and back in for it to take effect)"
+elif [ -n "$CHSH_SKIPPED_REASON" ]; then
+    ui_warning "Did not change default shell: $CHSH_SKIPPED_REASON"
+fi
+ui_section_end
+
 # --- Post-Install Instructions ---
 ui_final_success "Franklin installation complete!"
 echo "" >&2
 echo "Next steps:" >&2
-echo "  1. Add Franklin to your PATH by adding this to your .zshrc (optional if you're using the Franklin .zshrc template):" >&2
-echo "     export PATH=\"${VENV_DIR}/bin:\$PATH\"" >&2
+if [ "$CHSH_CHANGED" = true ]; then
+    echo "  1. Log out and back in (or open a new terminal) so zsh becomes your login shell." >&2
+    echo "     For this session, run: exec zsh" >&2
+else
+    echo "  1. Restart your shell or run: exec zsh" >&2
+    echo "     To also make zsh your default shell: chsh -s \"$(command -v zsh 2>/dev/null || echo /usr/bin/zsh)\"" >&2
+fi
 echo "" >&2
-echo "  2. Restart your shell or run: exec zsh" >&2
-echo "" >&2
-echo "  3. Verify installation with: franklin doctor" >&2
+echo "  2. Verify installation with: franklin doctor" >&2
 echo "" >&2


### PR DESCRIPTION
## Summary

Fixes the bug you hit on the Raspberry Pi — after install completed, SSH'ing back in dropped you into bash, not zsh, so none of the Franklin setup was visible.

### Root cause

`install.sh` has always just symlinked `.zshrc` and printed `Restart your shell or run: exec zsh` in the post-install steps. It **never called `chsh`**. On any distro where bash is the default login shell (basically every Linux image, including fresh Raspberry Pi OS), the next SSH session still loads bash, bash doesn't source `.zshrc`, and Franklin's environment effectively doesn't exist.

This has likely been latent since v1.x; it's been hidden on systems where the user had previously run `chsh` themselves.

### Fix

After all the config linking is done, `install.sh` now:

1. Checks the current `$SHELL` — if it's already zsh, no-op with a clear branch message.
2. Ensures `zsh`'s path is registered in `/etc/shells` (appending via `sudo tee -a` if not).
3. Runs `chsh -s "$(command -v zsh)"` for the current user.
4. Reports whether the change succeeded — "log out and back in" vs "run chsh manually".

**Important TTY detail:** the password prompt reads from `/dev/tty` explicitly (`chsh -s … </dev/tty`). That's because when users install via `curl -fsSL … | bash`, stdin is the pipe, not a terminal, so PAM's password prompt would otherwise fail. Reading from `/dev/tty` works in interactive SSH / terminal sessions regardless of how the script was launched.

### Guards (no silent failures)

The chsh step is skipped — with a clear warning every time — for any of:
- `--no-chsh` flag was passed (new opt-out)
- zsh is not on `PATH` (dependency install failed upstream)
- `chsh` isn't available on the system
- Current `$SHELL` is already zsh
- `/dev/tty` isn't a character device (running under cron, a systemd unit, or another non-interactive context)
- `chsh` itself exits non-zero (password declined, PAM unhappy, etc.)

In every skip/fail case, the user sees the exact `chsh -s /usr/bin/zsh` invocation they'd need to run manually.

### Post-install "Next steps" now reflects reality

Before:
```
  1. Add Franklin to your PATH by adding this to your .zshrc (optional if you're using the Franklin .zshrc template)
  2. Restart your shell or run: exec zsh
  3. Verify installation with: franklin doctor
```

After (when chsh succeeded):
```
  1. Log out and back in (or open a new terminal) so zsh becomes your login shell.
     For this session, run: exec zsh
  2. Verify installation with: franklin doctor
```

After (when chsh was skipped):
```
  1. Restart your shell or run: exec zsh
     To also make zsh your default shell: chsh -s "/usr/bin/zsh"
  2. Verify installation with: franklin doctor
```

## Test plan

- [ ] Fresh Raspberry Pi OS image (or any Debian/Ubuntu cloud VM): run the bootstrap, enter password when chsh prompts, SSH back in, verify the prompt is zsh (Starship), Franklin MOTD renders.
- [ ] macOS: re-run `install.sh`; since `$SHELL` is already zsh on modern macOS, verify the chsh step no-ops cleanly.
- [ ] Fedora: same as Debian test.
- [ ] `bash franklin/src/install.sh --non-interactive --no-chsh` — verify the chsh step is skipped with a "did not change default shell" warning.
- [ ] Invoke via `curl | bash` (to simulate the pipe case): verify the `</dev/tty` redirect lets the password prompt display and accept input on an interactive SSH session.
- [ ] Invoke install.sh with stdin closed (e.g. `bash install.sh </dev/null`): verify it skips chsh with the "no controlling TTY" warning instead of hanging.

## Related

Pairs naturally with PR #8 (bootstrap auto-installs git/curl/python3). Together they mean that a truly fresh Raspberry Pi → login → `curl | bash` flow now completes without user intervention and produces a real zsh login shell on reconnect.

https://claude.ai/code/session_01L6DH2fz6xtpoKMbvCK9Tks