### PR TITLE
change(install): --non-interactive installs everything; nudge when MOTD color defaulted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - **`--non-interactive` now means "install everything" instead of "skip anything optional".** Previously, running `install.sh --non-interactive` silently skipped Claude Code — you had to add `--with-claude` to get it. That made the flag awkward: a user automating a fresh install had to remember every opt-in flag just to get the same result an interactive TTY would produce by default. The new model is: non-interactive mode installs every optional piece and picks the default MOTD color; if you want to skip something, use the corresponding `--no-*` flag (`--no-claude`, `--no-chsh`). `--with-claude` still works for forcing Claude Code in interactive mode without being prompted. Automation scripts that previously used `--non-interactive --with-claude` can drop `--with-claude`; scripts that relied on the old "skip Claude" default need to add `--no-claude`.
+- **Post-install now nudges you about the MOTD color when it defaulted.** When the non-interactive path silently falls back to the default Cello banner, the final "Next steps" block explicitly shows `franklin config --color <name>` as step 3 with example names, so users notice they can personalize it instead of silently accepting the default forever.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`--non-interactive` now means "install everything" instead of "skip anything optional".** Previously, running `install.sh --non-interactive` silently skipped Claude Code — you had to add `--with-claude` to get it. That made the flag awkward: a user automating a fresh install had to remember every opt-in flag just to get the same result an interactive TTY would produce by default. The new model is: non-interactive mode installs every optional piece and picks the default MOTD color; if you want to skip something, use the corresponding `--no-*` flag (`--no-claude`, `--no-chsh`). `--with-claude` still works for forcing Claude Code in interactive mode without being prompted. Automation scripts that previously used `--non-interactive --with-claude` can drop `--with-claude`; scripts that relied on the old "skip Claude" default need to add `--no-claude`.
+
 ### Fixed
 
 - **`install.sh` now actually makes zsh the default login shell.** This was a long-standing bug: the installer symlinked `.zshrc` and printed `Restart your shell or run: exec zsh` in the post-install steps but never ran `chsh`, so users logging back in via SSH would land in bash (which doesn't source `.zshrc`) and see none of their Franklin setup. The installer now ensures `zsh` is registered in `/etc/shells`, runs `chsh -s $(command -v zsh)` for the current user (reading the password prompt from `/dev/tty` so it works under `curl | bash` too), and reports whether the change succeeded. Opt out with the new `--no-chsh` flag.

--- a/README.md
+++ b/README.md
@@ -100,10 +100,12 @@ The prompt is powered by [Starship](https://starship.rs/). You can customize it 
 
 ### Advanced Configuration
 
-- **Claude Code**: The installer can optionally install [Claude Code](https://docs.anthropic.com/en/docs/claude-code) via Anthropic's native installer (no Node dependency). On a TTY, `install.sh` prompts you; in non-interactive mode it skips unless `--with-claude` is passed. Use `--no-claude` to skip the prompt entirely. Example:
+- **Claude Code**: The installer installs [Claude Code](https://docs.anthropic.com/en/docs/claude-code) via Anthropic's native installer (no Node dependency). On a TTY, `install.sh` prompts you (default: yes); in non-interactive mode it installs by default. Use `--no-claude` to skip. Example of skipping:
   ```bash
-  bash install.sh --non-interactive --color cello --with-claude
+  bash install.sh --non-interactive --color cello --no-claude
   ```
+
+- **Non-interactive philosophy**: `--non-interactive` means "install everything and pick sensible defaults, no prompts." If you want to skip an optional piece, use the corresponding `--no-*` flag (`--no-claude`, `--no-chsh`, etc.). The `--with-claude` flag still exists for interactive runs where you want to install Claude Code without being prompted.
 
 - **Backup Location**: To change where Franklin stores backups of your old dotfiles, set the `FRANKLIN_BACKUP_DIR` environment variable *before* running the installer.
   ```bash

--- a/franklin/src/install.sh
+++ b/franklin/src/install.sh
@@ -136,6 +136,11 @@ ui_header "Configuring MOTD color"
 # Default color
 MOTD_COLOR="#607a97"  # Cello
 MOTD_COLOR_NAME="Cello"
+# Tracks whether the user actively chose the color (via --color or the
+# interactive picker) vs. silently got the default in non-interactive mode.
+# The post-install summary uses this to nudge non-interactive users toward
+# `franklin config --color <name>` so they don't miss that they're on default.
+COLOR_WAS_DEFAULTED=false
 
 # Handle preset color from --color flag. Accepts Title Case ("Mauve Earth"),
 # lowercase ("mauve earth"), and kebab-case ("mauve-earth") forms for any
@@ -216,6 +221,7 @@ elif [ -t 0 ] && [ "$NON_INTERACTIVE" = false ]; then
     esac
 else
     ui_branch "Non-interactive mode, using default color (Cello)"
+    COLOR_WAS_DEFAULTED=true
 fi
 
 # Save color to config
@@ -631,3 +637,12 @@ fi
 echo "" >&2
 echo "  2. Verify installation with: franklin doctor" >&2
 echo "" >&2
+
+# MOTD color nudge: if the non-interactive path silently defaulted to Cello,
+# tell the user loudly so they don't miss that they can personalize it.
+if [ "$COLOR_WAS_DEFAULTED" = true ]; then
+    echo "  3. Your MOTD banner color is set to the default (Cello). Pick your own:" >&2
+    echo "     franklin config --color <name>   # clay, ember, sage, flamingo, mauve-earth, ..." >&2
+    echo "     (14 Campfire colors available; see README or run 'franklin config' for the picker)" >&2
+    echo "" >&2
+fi

--- a/franklin/src/install.sh
+++ b/franklin/src/install.sh
@@ -13,10 +13,12 @@
 # 7. Installs the Franklin CLI via Python
 #
 # Flags:
-#   --non-interactive   Skip interactive prompts (use defaults)
+#   --non-interactive   Skip interactive prompts (install everything by default,
+#                       use the default MOTD color). Opt out of specific steps
+#                       with the --no-* flags below.
 #   --color NAME        Pre-select MOTD color (e.g., Cello, Terracotta)
-#   --with-claude       Install Claude Code (native installer) without prompting
-#   --no-claude         Skip Claude Code installation without prompting
+#   --with-claude       Install Claude Code even in interactive mode (no prompt)
+#   --no-claude         Skip Claude Code installation
 #   --no-chsh           Don't change the user's default login shell to zsh
 
 set -euo pipefail
@@ -402,21 +404,24 @@ fi
 ui_success "mise ready"
 ui_section_end
 
-# --- Install Claude Code (optional) ---
-ui_header "Claude Code (optional)"
+# --- Install Claude Code ---
+ui_header "Claude Code"
 
-# Decide whether to install:
-#   CLAUDE_CHOICE set via --with-claude / --no-claude wins.
-#   Otherwise prompt interactively (default: yes).
-#   In non-interactive mode without a flag, skip.
+# Decision order:
+#   1. Already installed -> skip.
+#   2. --no-claude -> skip.
+#   3. --with-claude -> install without prompting.
+#   4. Interactive TTY -> prompt (default: yes).
+#   5. Non-interactive (no flag) -> install by default. Non-interactive means
+#      "install everything"; use --no-claude to opt out.
 if command -v claude >/dev/null 2>&1; then
     ui_branch "Claude Code already installed, skipping"
     CLAUDE_INSTALL=false
-elif [ "$CLAUDE_CHOICE" = "yes" ]; then
-    CLAUDE_INSTALL=true
 elif [ "$CLAUDE_CHOICE" = "no" ]; then
     ui_branch "Skipping Claude Code install (--no-claude)"
     CLAUDE_INSTALL=false
+elif [ "$CLAUDE_CHOICE" = "yes" ]; then
+    CLAUDE_INSTALL=true
 elif [ -t 0 ] && [ "$NON_INTERACTIVE" = false ]; then
     echo "" >&2
     echo "Claude Code is Anthropic's official CLI for Claude." >&2
@@ -428,14 +433,14 @@ elif [ -t 0 ] && [ "$NON_INTERACTIVE" = false ]; then
         *)         CLAUDE_INSTALL=true ;;
     esac
 else
-    ui_branch "Non-interactive mode, skipping Claude Code (use --with-claude to install)"
-    CLAUDE_INSTALL=false
+    ui_branch "Non-interactive mode: installing Claude Code by default (use --no-claude to skip)"
+    CLAUDE_INSTALL=true
 fi
 
 if [ "${CLAUDE_INSTALL:-false}" = true ]; then
     ui_branch "Installing Claude Code via native installer..."
     if ! curl -fsSL https://claude.ai/install.sh | bash 2>&1 | sed 's/^/  /' >&2; then
-        ui_error_noexit "Claude Code installer failed (non-fatal, rerun install.sh --with-claude later)"
+        ui_error_noexit "Claude Code installer failed (non-fatal, rerun install.sh later)"
     else
         ui_success "Claude Code installed"
     fi


### PR DESCRIPTION
## Summary

Two related changes to the `install.sh` flag model, based on your observation that "non-interactive mode should install everything":

### 1. `--non-interactive` now installs everything by default

Before: `--non-interactive` silently skipped Claude Code. You had to add `--with-claude` to get a full install — meaning automation scripts had to remember every opt-in flag to match what an interactive user got by default.

After: `--non-interactive` means **"install everything and pick sensible defaults, no prompts."** Skip specific pieces with the corresponding `--no-*` flag:

| Flag | Effect |
|---|---|
| `--non-interactive` | Installs everything, uses default MOTD color, attempts chsh |
| `--non-interactive --no-claude` | Same but skips Claude Code |
| `--non-interactive --no-chsh` | Same but skips changing the login shell |
| `--with-claude` | Still works for interactive runs where you want Claude Code without being prompted |

Only Claude Code was affected by the old behavior — every other optional tool (eza, mise, Sheldon plugins, chsh) was already always attempted in both modes.

**Migration:**
- Old `install.sh --non-interactive --with-claude` → new `install.sh --non-interactive` (drop `--with-claude`).
- Old `install.sh --non-interactive` (which silently skipped Claude) → new `install.sh --non-interactive --no-claude` to preserve that behavior.

### 2. Post-install nudge about MOTD color when it defaulted

Your follow-up point: if a user runs non-interactively and silently gets the default Cello banner, they might never realize they could personalize it. The installer now tracks whether the color was actually chosen (via `--color` or the interactive picker) vs. silently defaulted.

When the color **was** defaulted, the post-install summary adds a step 3:

```
  3. Your MOTD banner color is set to the default (Cello). Pick your own:
     franklin config --color <name>   # clay, ember, sage, flamingo, mauve-earth, ...
     (14 Campfire colors available; see README or run 'franklin config' for the picker)
```

If the user actively picked a color (via `--color` or the interactive prompt), no nudge — we don't nag people who already chose.

## Why not "always force color choice"?

You offered two options ("user should have to choose their color, no matter what. Either that, or … be more explicit in the final messaging"). I went with the messaging path because **forcing `--color` in non-interactive mode** would:

1. Break the "install everything with defaults, no prompts" model we just established.
2. Turn every automation script into a two-step thing where the operator has to remember the `--color` flag up front.
3. Make the installer fail for anyone bootstrapping a brand-new machine via `curl | bash` without having picked a color in advance.

The nudge approach keeps defaults working for automation but makes sure no one installs and silently lives with Cello forever. If you'd rather force the choice, happy to swap the approach — it'd be a one-line change to make `--non-interactive` require `--color`.

## Test plan

- [ ] `bash install.sh --non-interactive` (no flags): Claude installs, color defaults to Cello, chsh runs, **color nudge appears** in step 3.
- [ ] `bash install.sh --non-interactive --color ember`: Claude installs, color is Ember, **no nudge** (user chose).
- [ ] `bash install.sh --non-interactive --no-claude`: everything else installs, Claude skipped, color nudge appears.
- [ ] `bash install.sh --non-interactive --color pine --no-claude --no-chsh`: Pine banner, no Claude, no shell change, no nudge.
- [ ] Interactive TTY install: color picker still runs (user chooses); Claude prompt still defaults to Y; **no nudge** in post-install since user actively chose.

https://claude.ai/code/session_01L6DH2fz6xtpoKMbvCK9Tks