### PR TITLE
change(install): detect installed deps before shelling out to pkg manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`install.sh` detects already-installed dependencies before shelling out to the package manager.** Previously every run issued the full `brew install …` / `apt-get update && apt-get install …` / `dnf install …` command, even on machines where git/curl/zsh/python3/bat were already present. On a re-run (or any non-fresh box) this is wasted work and noisy output. The installer now walks each core tool with `command -v` first, builds a `MISSING` list per platform, and only calls the package manager when something's actually needed. Special-cases: Debian's `bat` package installs the binary as `batcat` (either satisfies the check); `python3-venv` is a module detected via `python3 -c "import venv"`; `python3-pip` is detected via `pip3` / `python3 -m pip`. When `MISSING` is empty we skip `apt-get update` entirely, which is the biggest win on slow/metered connections (e.g. Raspberry Pi over Wi-Fi). Existing `eza` / `sheldon` / `starship` blocks on Debian/Fedora already had `command -v` guards and are unchanged.
+
 ## [2.1.1] - 2026-04-17
 
 ### Changed

--- a/franklin/src/install.sh
+++ b/franklin/src/install.sh
@@ -246,6 +246,15 @@ ui_header "Installing dependencies"
 
 INSTALL_FAILED=false
 
+# Detection helper. Appends $2 (package name) to MISSING if $1 (binary) isn't
+# on PATH. Keeps each per-platform block readable and lets us skip the package
+# manager entirely on a re-run when everything's already installed.
+_pkg_need() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        MISSING+=("$2")
+    fi
+}
+
 case "$OS_FAMILY" in
     macos)
         # Check for Homebrew and add to PATH if needed
@@ -264,23 +273,59 @@ case "$OS_FAMILY" in
             fi
         fi
 
-        # Install dependencies
-        ui_branch "Installing packages via Homebrew..."
-        if ! brew install curl git zsh python3 bat eza sheldon starship 2>&1 | sed 's/^/      /' >&2; then
-            ui_error_noexit "Some Homebrew packages failed to install"
-            INSTALL_FAILED=true
+        MISSING=()
+        _pkg_need curl     curl
+        _pkg_need git      git
+        _pkg_need zsh      zsh
+        _pkg_need python3  python3
+        _pkg_need bat      bat
+        _pkg_need eza      eza
+        _pkg_need sheldon  sheldon
+        _pkg_need starship starship
+
+        if [ ${#MISSING[@]} -eq 0 ]; then
+            ui_branch "All Homebrew packages already installed, skipping brew install"
+        else
+            ui_branch "Installing via Homebrew: ${MISSING[*]}"
+            if ! brew install "${MISSING[@]}" 2>&1 | sed 's/^/      /' >&2; then
+                ui_error_noexit "Some Homebrew packages failed to install"
+                INSTALL_FAILED=true
+            fi
         fi
         ;;
 
     debian)
-        ui_branch "Installing packages via apt..."
-        if ! sudo apt-get update -qq 2>&1 | sed 's/^/      /' >&2; then
-            ui_error_noexit "apt-get update failed"
-            INSTALL_FAILED=true
+        MISSING=()
+        _pkg_need curl    curl
+        _pkg_need git     git
+        _pkg_need zsh     zsh
+        _pkg_need python3 python3
+        # python3-venv ships as a module, no binary of its own
+        if ! python3 -c "import venv" >/dev/null 2>&1; then
+            MISSING+=(python3-venv)
         fi
-        if ! sudo apt-get install -y -qq curl git zsh python3 python3-venv python3-pip bat 2>&1 | sed 's/^/      /' >&2; then
-            ui_error_noexit "Some apt packages failed to install"
-            INSTALL_FAILED=true
+        # python3-pip provides `pip3` and/or `python3 -m pip`
+        if ! command -v pip3 >/dev/null 2>&1 && ! python3 -m pip --version >/dev/null 2>&1; then
+            MISSING+=(python3-pip)
+        fi
+        # Debian's `bat` package installs the binary as `batcat` to avoid
+        # conflicting with another tool; the zshrc aliases accordingly.
+        if ! command -v bat >/dev/null 2>&1 && ! command -v batcat >/dev/null 2>&1; then
+            MISSING+=(bat)
+        fi
+
+        if [ ${#MISSING[@]} -eq 0 ]; then
+            ui_branch "All apt packages already installed, skipping apt-get update"
+        else
+            ui_branch "Installing via apt: ${MISSING[*]}"
+            if ! sudo apt-get update -qq 2>&1 | sed 's/^/      /' >&2; then
+                ui_error_noexit "apt-get update failed"
+                INSTALL_FAILED=true
+            fi
+            if ! sudo apt-get install -y -qq "${MISSING[@]}" 2>&1 | sed 's/^/      /' >&2; then
+                ui_error_noexit "Some apt packages failed to install"
+                INSTALL_FAILED=true
+            fi
         fi
 
         # Install Sheldon (not in apt)
@@ -313,10 +358,24 @@ case "$OS_FAMILY" in
         ;;
 
     fedora)
-        ui_branch "Installing packages via dnf..."
-        if ! sudo dnf install -y curl git zsh python3 python3-pip bat 2>&1 | sed 's/^/      /' >&2; then
-            ui_error_noexit "Some dnf packages failed to install"
-            INSTALL_FAILED=true
+        MISSING=()
+        _pkg_need curl    curl
+        _pkg_need git     git
+        _pkg_need zsh     zsh
+        _pkg_need python3 python3
+        if ! command -v pip3 >/dev/null 2>&1 && ! python3 -m pip --version >/dev/null 2>&1; then
+            MISSING+=(python3-pip)
+        fi
+        _pkg_need bat bat
+
+        if [ ${#MISSING[@]} -eq 0 ]; then
+            ui_branch "All dnf packages already installed, skipping dnf install"
+        else
+            ui_branch "Installing via dnf: ${MISSING[*]}"
+            if ! sudo dnf install -y "${MISSING[@]}" 2>&1 | sed 's/^/      /' >&2; then
+                ui_error_noexit "Some dnf packages failed to install"
+                INSTALL_FAILED=true
+            fi
         fi
 
         # Install Sheldon (not in dnf)


### PR DESCRIPTION
## Summary

Makes `install.sh` detect which dependencies are already present before shelling out to `brew` / `apt-get` / `dnf`. Motivated by your observation that on an existing machine, a lot of the `apt install` work is wasted: the packages are already there, and `apt-get update` alone is 10-30 seconds of network chatter on a Raspberry Pi over Wi-Fi.

## Before

Every run, regardless of host state:
```
brew   install curl git zsh python3 bat eza sheldon starship
apt-get update && apt-get install -y -qq curl git zsh python3 python3-venv python3-pip bat
dnf    install -y curl git zsh python3 python3-pip bat
```

## After

Each platform block builds a `MISSING` list with a new `_pkg_need` helper:

```bash
_pkg_need() {
    if ! command -v "$1" >/dev/null 2>&1; then
        MISSING+=("$2")
    fi
}

MISSING=()
_pkg_need curl    curl
_pkg_need git     git
_pkg_need zsh     zsh
_pkg_need python3 python3
# … special cases below …

if [ ${#MISSING[@]} -eq 0 ]; then
    ui_branch "All apt packages already installed, skipping apt-get update"
else
    ui_branch "Installing via apt: ${MISSING[*]}"
    sudo apt-get update -qq
    sudo apt-get install -y -qq "${MISSING[@]}"
fi
```

Concrete payoff: on a re-run or any already-provisioned box, we skip `apt-get update` **entirely** (and the bulk install call).

## Special cases handled

| Tool | Check | Notes |
|---|---|---|
| `bat` on Debian | `command -v bat` **or** `command -v batcat` | Debian's `bat` package installs the binary as `batcat` to avoid conflicting with another tool (zshrc already aliases accordingly). Either satisfies "bat is installed." |
| `python3-venv` | `python3 -c "import venv"` | It's a module, not a binary — `command -v` won't find it. |
| `python3-pip` | `command -v pip3` **or** `python3 -m pip --version` | Covers both installation shapes. |

## What's unchanged

- `eza`, `sheldon`, `starship` blocks on Debian/Fedora already had `command -v` guards. Left alone.
- macOS bulk brew install still covers all 8 tools; only the `brew install` invocation itself is filtered by MISSING.
- `INSTALL_FAILED` semantics preserved for the downstream summary.

## Test plan

- [ ] Fresh Debian VM (nothing installed): verify `MISSING` contains the full list, `apt-get update` + `apt-get install` both run.
- [ ] Same machine after install completes: re-run `install.sh --non-interactive`. Expect `All apt packages already installed, skipping apt-get update` and a noticeably faster run.
- [ ] Debian VM with git preinstalled but nothing else: `MISSING` excludes `git` but includes the rest; single `apt-get install` runs with a shorter arg list.
- [ ] Debian VM where `bat` is present as `batcat`: `MISSING` does not include `bat`.
- [ ] macOS: verify brew install only runs for missing packages; re-run prints "All Homebrew packages already installed".
- [ ] Fedora 38+: similar verification.
- [ ] Any platform with `python3-venv` missing (can force: `apt remove --purge python3-venv`): re-run picks it up via the `import venv` check.

https://claude.ai/code/session_01L6DH2fz6xtpoKMbvCK9Tks