### PR TITLE
fix(install): chsh password prompt was invisible (line-buffered by sed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`chsh` password prompt is now actually visible.** The v2.1.1 chsh step piped chsh's stderr through `sed` to indent it, but `chsh`'s PAM `Password:` prompt has no trailing newline. `sed` is line-buffered, so it held the prompt in its buffer until a newline arrived — the user saw nothing, hit Enter thinking the script had hung, and PAM rejected the empty password with `Authentication failure`. The installer now runs `chsh` without piping (no indentation, but the prompt appears immediately), redirects stdin **and** stderr to `/dev/tty` so the prompt is guaranteed visible and readable even under `curl | bash`, and pre-announces "chsh will prompt for your login password below" so the user knows to expect it. The `/etc/shells` registration step also stops swallowing stderr (`2>/dev/null`) so any sudo prompt there is visible too.
+
 ## [2.1.1] - 2026-04-17
 
 ### Changed

--- a/franklin/src/install.sh
+++ b/franklin/src/install.sh
@@ -568,12 +568,16 @@ CHSH_SKIPPED_REASON=""
 _install_ensure_zsh_in_shells() {
     local zsh_path="$1"
     # /etc/shells exists on every supported OS; if the path is already there
-    # we don't need sudo.
+    # we don't need sudo (and this is the usual case — apt/dnf/brew register
+    # zsh automatically during install).
     if [ -f /etc/shells ] && grep -Fxq "$zsh_path" /etc/shells; then
         return 0
     fi
-    ui_branch "Registering $zsh_path in /etc/shells..."
-    if echo "$zsh_path" | sudo tee -a /etc/shells >/dev/null 2>&1; then
+    # Only reaches here if zsh was installed in some unusual way that left it
+    # out of /etc/shells. Don't swallow stderr so the user can see any sudo
+    # password prompt.
+    ui_branch "Registering $zsh_path in /etc/shells (sudo required)..."
+    if echo "$zsh_path" | sudo tee -a /etc/shells >/dev/null; then
         return 0
     fi
     return 1
@@ -593,18 +597,32 @@ else
         ui_branch "zsh is already the default shell ($ZSH_PATH)"
     else
         if _install_ensure_zsh_in_shells "$ZSH_PATH"; then
-            # chsh prompts for the user's password via PAM. When install.sh
-            # is launched through `curl | bash`, stdin is the pipe so the
-            # prompt can't read; redirecting from /dev/tty works around that
-            # in interactive SSH / terminal sessions. If /dev/tty isn't
-            # available (cron, systemd unit, etc.), skip.
+            # chsh prompts for the user's password via PAM. Two pitfalls to
+            # dodge here:
+            #   1. When install.sh is launched via `curl | bash`, stdin is
+            #      the pipe so the prompt can't read. Redirect from /dev/tty
+            #      so the prompt reads from the user's actual terminal.
+            #   2. The "Password:" prompt is printed WITHOUT a trailing
+            #      newline. If we pipe chsh's stderr through `sed`, sed's
+            #      line-buffering swallows the prompt until a newline shows
+            #      up — the user sees nothing, hits Enter thinking it hung,
+            #      and PAM rejects the empty password. So we do NOT pipe
+            #      chsh output at all: it inherits stderr directly and the
+            #      prompt appears instantly.
             if [ ! -c /dev/tty ]; then
                 CHSH_SKIPPED_REASON="no controlling TTY for chsh password prompt"
             else
-                ui_branch "Changing default shell to $ZSH_PATH..."
-                if chsh -s "$ZSH_PATH" </dev/tty 2>&1 | sed 's/^/      /' >&2; then
+                ui_branch "Changing default shell to $ZSH_PATH"
+                ui_branch "chsh will prompt for your login password below:"
+                echo "" >&2
+                # Redirect stdin AND stderr explicitly to /dev/tty so the PAM
+                # prompt is guaranteed visible and readable regardless of how
+                # install.sh's own fds were wired up by the caller.
+                if chsh -s "$ZSH_PATH" </dev/tty 2>/dev/tty; then
+                    echo "" >&2
                     CHSH_CHANGED=true
                 else
+                    echo "" >&2
                     ui_warning "chsh failed. You can finish the change manually: chsh -s $ZSH_PATH"
                     CHSH_SKIPPED_REASON="chsh invocation failed"
                 fi


### PR DESCRIPTION
## Summary

Fixes the regression you hit on the Raspberry Pi:

```
Changing default shell to /usr/bin/zsh...
      Password:
      chsh: PAM: Authentication failure
⎿  ⚠ chsh failed. You can finish the change manually: chsh -s /usr/bin/zsh
```

You saw the script appear to hang, pressed Enter to try to unstick it, and PAM rejected the resulting empty password.

## Root cause

The v2.1.1 chsh invocation was:

```bash
chsh -s "$ZSH_PATH" </dev/tty 2>&1 | sed 's/^/      /' >&2
```

`chsh`'s PAM `Password:` prompt is printed **without a trailing newline** (standard for password prompts). `sed` is line-buffered by default — it buffers input until it sees a newline before flushing. So the prompt sat in sed's buffer indefinitely; your terminal showed nothing. When you pressed Enter, you sent `\n` on stdin (an empty password), PAM rejected it, and *then* sed flushed the buffered `Password:` text retroactively — which is what you saw in the log output, long after the interactive moment had passed.

## Fix

1. **Stop piping chsh output.** The indentation wasn't worth breaking the interactive prompt. `chsh` now runs without a pipe, so its output hits the terminal instantly.
2. **Redirect stdin *and* stderr to `/dev/tty` explicitly:**
   ```bash
   chsh -s "$ZSH_PATH" </dev/tty 2>/dev/tty
   ```
   This guarantees the prompt is visible and readable even if install.sh's own fds were wired up oddly by the caller (e.g. `curl | bash`, CI wrappers that redirect stderr to a log).
3. **Pre-announce the prompt** so the user isn't caught off guard:
   ```
   ⎿  Changing default shell to /usr/bin/zsh
   ⎿  chsh will prompt for your login password below:

   Password: _
   ```
4. **Stopped swallowing stderr in the `/etc/shells` registration helper** (`sudo tee ... 2>/dev/null` → `sudo tee ... >/dev/null`). In practice sudo writes to `/dev/tty` directly so the prompt was usually fine, but it's defensible to keep any sudo diagnostic visible if something does go wrong.

## Why this hit chsh but not the earlier apt/dnf sudo prompts

`sudo` writes its own password prompt to `/dev/tty` directly, bypassing stdout/stderr entirely — so the existing `sudo apt-get … 2>&1 | sed …` pattern in install.sh displays the sudo prompt just fine. `chsh` authenticates via PAM's conversation interface instead, and `pam_unix` writes prompts to stderr using buffered libc stdio — which is exactly what the `| sed` pipe mangles. Narrow, specific fix; other sudo calls didn't need changes.

## Test plan

- [ ] Fresh Raspberry Pi / Debian / Ubuntu: run `install.sh`, verify the password prompt appears immediately and is readable, enter password, confirm chsh succeeds.
- [ ] Same thing via `curl -fsSL …bootstrap.sh | bash`: verify the prompt still appears (the explicit `2>/dev/tty` should cover this).
- [ ] `bash install.sh --no-chsh`: verify chsh step is skipped entirely.
- [ ] macOS: verify the chsh step runs cleanly (your `$SHELL` is probably already zsh so it should no-op).
- [ ] Force a chsh failure (e.g. wrong password): verify the warning message still lands and the installer continues.

## Note

This branched off `main`, not off PR #12. If you merge PR #12 first, this should rebase cleanly — it only touches the chsh block in install.sh (lines ~595-617 area) which PR #12 doesn't go near.

https://claude.ai/code/session_01L6DH2fz6xtpoKMbvCK9Tks