### PR TITLE
docs(release): codify the end-to-end release playbook in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,11 +122,62 @@ Scopes: `cli`, `install`, `update`, `ui`, `motd`, `config`
 
 ## Release Workflow
 
-1. Update `CHANGELOG.md` under `[Unreleased]`
-2. Sync version in `VERSION` and `franklin/pyproject.toml`
-3. Commit: `release: vX.Y.Z`
-4. Tag: `git tag vX.Y.Z && git push origin main --tags`
-5. Create GitHub release from tag
+When the user asks to cut a release — any phrasing ("cut a release", "ship v2.1.3", "tag and publish") — the assistant runs the full playbook below. The user's only manual steps are to merge the PR and (until the git-proxy blocker is lifted) push the tag and click Publish. The assistant never hands off changelog curation, version math, or SHA lookup.
+
+### Step 1 — Agent: open the release PR
+
+1. Decide the version.
+   - **Patch** (`X.Y.Z+1`): only fixes, tiny UX refinements, docs.
+   - **Minor** (`X.Y+1.0`): new user-visible features, CLI subcommands/flags, install dependencies.
+   - **Major** (`X+1.0.0`): breaking changes to flags, config formats, CLI contracts, or install layout.
+   - Ask the user when `[Unreleased]` is ambiguous; default to patch otherwise.
+2. Branch from tip of `main`: `claude/release-vX.Y.Z`.
+3. Update:
+   - `VERSION` → `X.Y.Z`
+   - `franklin/pyproject.toml` → `version = "X.Y.Z"`
+   - `CHANGELOG.md` → promote `[Unreleased]` to `[X.Y.Z] - <today>` and leave a fresh empty `[Unreleased]` block above it.
+4. Commit with `release: vX.Y.Z` and a body summarising the changes since the prior tag (grouped by PR).
+5. Push and open the PR (title: `release: vX.Y.Z`).
+
+### Step 2 — User: merge the release PR
+
+Standard "merge commit" method (matches every prior Franklin release).
+
+### Step 3 — Agent: tag and prepare the publish kit
+
+After the merge webhook fires, the assistant:
+
+1. `git checkout main && git pull origin main` to fast-forward locally.
+2. `git tag -a vX.Y.Z <merge-sha> -m "Franklin vX.Y.Z"` on the merge commit.
+3. Attempts `git push origin vX.Y.Z`. **This currently 403s** because the localhost git proxy filters `refs/tags/*` pushes (see "Known blocker" below).
+
+**Regardless of whether the tag push succeeded**, the assistant posts a single "publish kit" message with:
+
+- The merge SHA.
+- A ready-to-run snippet for the user's local machine:
+  ```bash
+  git fetch origin
+  git tag -a vX.Y.Z <merge-sha> -m "Franklin vX.Y.Z"
+  git push origin vX.Y.Z
+  ```
+- The direct-click URL: `https://github.com/jeremyfuksa/franklin/releases/new?tag=vX.Y.Z`
+- The release **title**: `Franklin vX.Y.Z`.
+- The release **body**: ready-to-paste Markdown pulled from the new CHANGELOG section, reorganised into a short "Highlights" summary at the top with a link back to the CHANGELOG for the full detail block.
+
+### Step 4 — User: push the tag and publish
+
+1. Run the three-line `git` snippet from the publish kit.
+2. Open the URL from the publish kit.
+3. Paste title (if not already pre-filled) and body.
+4. Click **Publish release**.
+
+### Known blocker: tag push 403
+
+The localhost git proxy at `http://local_proxy@127.0.0.1:<port>/…` currently allows branch pushes but rejects `refs/tags/*` with HTTP 403. Once its ref-allowlist is relaxed to include tags, Step 3's push will succeed and the agent can (a) push the tag directly, (b) call `mcp__github__create_release` (once that tool is exposed by the MCP server's `repos` toolset), and skip the user's tag-push+click loop entirely.
+
+### Cross-project note
+
+This playbook lives in this repo's `CLAUDE.md`, so it applies to Franklin only. To get the same behaviour in another project, mirror this section into that project's `CLAUDE.md` (or add it to `~/.claude/CLAUDE.md` for every session, repo-agnostic).
 
 ## Key Principles
 


### PR DESCRIPTION
## Summary

Codifies the release playbook we've been following (and iterating on) from v2.1.0 through v2.1.2 into `CLAUDE.md` so every future agent session in this repo follows the same sequence automatically — no ad-hoc coordination every time.

Per the user request: *"make it an every-time occurrence that whenever I want to cut a release for anything on GitHub, you will do everything — give me the URL to click, give me the README to put in there, basically give me everything."*

## What the new section says

**Step 1 — Agent: open the release PR.**
- Decide patch/minor/major via a simple heuristic (with asking-when-ambiguous defaults).
- Branch `claude/release-vX.Y.Z` off `main`.
- Bump `VERSION`, `franklin/pyproject.toml`, promote `[Unreleased]` → `[X.Y.Z] - <today>`.
- Commit + push + open PR.

**Step 2 — User: merge the PR.**

**Step 3 — Agent: tag and prepare the publish kit.**
- Pull main, `git tag -a vX.Y.Z <merge-sha>` on the merge commit.
- Attempt `git push origin vX.Y.Z` (currently 403s; see "Known blocker").
- *Regardless of whether the push succeeded*, post a single publish-kit message with: merge SHA, ready-to-run local snippet, direct-click URL (`…/releases/new?tag=vX.Y.Z`), release title, and the release body pre-formatted from the CHANGELOG.

**Step 4 — User: push the tag + click Publish.**

**Known blocker**: the localhost git proxy currently rejects `refs/tags/*` pushes with HTTP 403. Until that's relaxed, the agent's tag push step always fails and the user runs the three-line git snippet locally. Once the proxy allows tag refs (and `mcp__github__create_release` is exposed), the agent can cover Step 3 end-to-end and the user's only manual step becomes merging Step 1's PR.

**Cross-project note**: to get the same behaviour in another repo, mirror the section into that repo's `CLAUDE.md`, or drop it in `~/.claude/CLAUDE.md` for repo-agnostic sessions.

## Why CLAUDE.md and not a skill / settings file

- CLAUDE.md is the canonical place for "instructions the agent should always follow in this repo" and is committed to the repo, versioned, and visible to reviewers.
- A skill would make sense if the release flow needed fresh logic each time; this is a stable procedure best expressed as durable documentation.
- No settings.json / hooks change would help here — the playbook is about agent behaviour and user-visible output, not harness configuration.

## Test plan

- [ ] After merge, next `cut a release` or similar phrasing should walk through the four steps verbatim, producing the publish kit format described in Step 3 without being asked for any extra coordination.

https://claude.ai/code/session_01L6DH2fz6xtpoKMbvCK9Tks