### PR TITLE
fix(zshrc): fall back to xterm-256color when TERM is unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Unknown `$TERM` values now fall back to `xterm-256color`** in the Franklin zshrc. Previously, SSH'ing into a Franklin-managed host from a terminal advertising a `TERM` value the host's terminfo didn't know (most commonly Ghostty's `xterm-ghostty` connecting to a host without ghostty terminfo installed) caused two compounding visible failures: zsh's line editor mis-computed column widths, so each keystroke duplicated characters in the redraw (`claude` rendering as `claudellaauudde`), and color escapes were emitted literally because the terminfo entry didn't claim 256-color support. The zshrc now probes the active `TERM` with `infocmp -q` early in startup and exports `TERM=xterm-256color` if it's unknown — preserving 256-color support and a sane line editor without requiring per-host terminfo installation.
+
 ## [2.1.2] - 2026-04-17
 
 ### Changed

--- a/franklin/templates/zshrc.zsh
+++ b/franklin/templates/zshrc.zsh
@@ -6,6 +6,18 @@
 export FRANKLIN_ROOT="${HOME}/.local/share/franklin"
 export FRANKLIN_CONFIG="${HOME}/.config/franklin"
 
+# --- TERM Fallback ---
+# If the TERM value advertised by the connecting terminal isn't known to this
+# host's terminfo database, zsh's line editor mis-computes column widths
+# (causing duplicated/garbled characters as you type) and color escapes get
+# rendered literally. Most commonly hits Ghostty (TERM=xterm-ghostty) SSH'ing
+# into a host where ghostty terminfo isn't installed. Falling back to
+# xterm-256color preserves 256-color support and a sane line editor without
+# requiring any per-host setup.
+if [[ -n "${TERM:-}" ]] && ! infocmp -q "$TERM" >/dev/null 2>&1; then
+    export TERM=xterm-256color
+fi
+
 # --- PATH Management ---
 # Clean and deduplicate PATH, ensuring all required directories are present
 


### PR DESCRIPTION
## Summary

Fixes the bug you hit on the fresh Pi: Ghostty → SSH → zsh produced `claudellaauudde` (duplicated characters) and broken colors.

## Root cause

Ghostty advertises `TERM=xterm-ghostty`. Your Pi's terminfo database doesn't have an `xterm-ghostty` entry — `infocmp xterm-ghostty` would return "no such terminal type." When zsh sees an unknown `TERM`, it falls back to a degraded entry and:

- **Line editor mis-computes column widths.** Each redraw of the prompt+input line shifts the cursor by the wrong amount, so as you type, characters get re-emitted at the wrong positions. That's the `claude` → `claudellaauudde` pattern.
- **Color escape sequences fall through.** The fallback terminfo doesn't claim 256-color or 24-bit color support, so Starship's escape codes get either dropped or rendered literally.

## Fix

A small guard near the top of `templates/zshrc.zsh` (after the env exports, before PATH/plugins/prompts):

```zsh
# --- TERM Fallback ---
if [[ -n "${TERM:-}" ]] && ! infocmp -q "$TERM" >/dev/null 2>&1; then
    export TERM=xterm-256color
fi
```

`infocmp -q` is a quiet existence check. If the host doesn't know the advertised `TERM`, we silently fall back to `xterm-256color` — which is universally known, has 256-color support, and has a working line editor. Runs early enough that nothing downstream (PATH setup, sheldon, starship, mise, the MOTD render) sees the bogus value.

## Per-host alternative

For users who want full Ghostty features on the remote (Kitty graphics protocol, advanced cursor shapes, etc.), they can still install ghostty terminfo manually:

```bash
infocmp -x xterm-ghostty | ssh user@host 'tic -x -'
```

The fallback only triggers when that hasn't been done — so it never overrides a properly configured host.

## Why not handle this in `install.sh` instead

The mismatch is a property of the *connecting* terminal at session time, not the host's install state. A user could install Franklin from one terminal and SSH in later from a different one with a different `TERM`. The zshrc check evaluates at every shell startup, so it catches whichever terminal just connected.

## Test plan

- [ ] On the affected Pi: pull the new zshrc, open a new SSH session from Ghostty, type → no duplicated characters, prompt colors render correctly.
- [ ] Same Pi, SSH from a Kitty terminal (`TERM=xterm-kitty`, also commonly missing): verify same fix applies.
- [ ] SSH from plain Terminal.app (`TERM=xterm-256color`, already known everywhere): verify the guard is a no-op (`TERM` stays as-is).
- [ ] `echo $TERM` inside the new shell: `xterm-256color` if Ghostty client wasn't pre-configured, otherwise unchanged.
- [ ] Kill any stale `claude` process if you have one running in the broken shell before reconnecting.

https://claude.ai/code/session_01L6DH2fz6xtpoKMbvCK9Tks