### PR TITLE
feat(install): install Ghostty terminfo into ~/.terminfo on the host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`install.sh` installs Ghostty's terminfo into `~/.terminfo`** (best-effort) so that SSH'ing into a Franklin-managed host from Ghostty gets full-fidelity terminal support out of the box. Uses the upstream terminfo source from `ghostty-org/ghostty` and compiles it via `tic -x -o ~/.terminfo`; no sudo required. If the fetch fails (no network, no `tic`, etc.), the install warns and shows Ghostty's official one-liner from the docs at https://ghostty.org/docs/help/terminfo: `infocmp -x xterm-ghostty | ssh user@host -- tic -x -`. The zshrc `TERM=xterm-256color` fallback (also new in this release) catches anything that slips through. Works alongside the official "ssh-terminfo" Ghostty shell-integration feature, which auto-pushes terminfo on first connect when enabled on the client.
+
 ## [2.1.2] - 2026-04-17
 
 ### Changed

--- a/franklin/src/install.sh
+++ b/franklin/src/install.sh
@@ -615,6 +615,43 @@ ln -sf "${FRANKLIN_ROOT}/config/starship.toml" "$STARSHIP_CONFIG"
 ui_success "Starship config linked"
 ui_section_end
 
+# --- Modern terminal terminfo entries ---
+# When users SSH in from a modern terminal like Ghostty
+# (TERM=xterm-ghostty) and the host's terminfo doesn't know that entry,
+# zsh's line editor mis-computes column widths (-> duplicated characters
+# while typing) and color escapes get emitted literally.
+#
+# Ghostty's official terminfo install method is to push from the LOCAL
+# machine: `infocmp -x xterm-ghostty | ssh host -- tic -x -` (see
+# https://ghostty.org/docs/help/terminfo). That can't run during this
+# install — we're on the target host, not the source. We fall back to
+# fetching the upstream terminfo source and compiling it into
+# ~/.terminfo (no sudo). If the fetch fails, we point the user at the
+# official command. Either way, the zshrc TERM fallback (set TERM to
+# xterm-256color when unknown) keeps things working in the meantime.
+ui_header "Installing modern terminal terminfo entries"
+
+GHOSTTY_TERMINFO_URL="https://raw.githubusercontent.com/ghostty-org/ghostty/main/src/terminfo/ghostty.terminfo"
+GHOSTTY_OFFICIAL_HINT="For canonical install, run from your local machine: infocmp -x xterm-ghostty | ssh ${USER}@<this-host> -- tic -x -"
+
+if ! command -v tic >/dev/null 2>&1; then
+    ui_warning "tic not found (ncurses-bin missing); skipping Ghostty terminfo install"
+    ui_branch "$GHOSTTY_OFFICIAL_HINT"
+elif infocmp xterm-ghostty >/dev/null 2>&1; then
+    ui_branch "Ghostty terminfo already present, skipping"
+else
+    ui_branch "Installing Ghostty terminfo into ~/.terminfo (best-effort fetch from upstream)..."
+    if curl -fsSL "$GHOSTTY_TERMINFO_URL" | tic -x -o "${HOME}/.terminfo" - 2>&1 | sed 's/^/      /' >&2 \
+       && infocmp xterm-ghostty >/dev/null 2>&1; then
+        ui_success "Ghostty terminfo installed (xterm-ghostty)"
+    else
+        ui_warning "Ghostty terminfo install failed; zshrc TERM fallback will apply"
+        ui_branch "$GHOSTTY_OFFICIAL_HINT"
+    fi
+fi
+
+ui_section_end
+
 # --- Set zsh as the default login shell ---
 # Without this, SSH sessions and new terminals will still land in whatever
 # shell was the default (bash on most Linux distros), meaning the Franklin


### PR DESCRIPTION
## Summary

Companion to #16. Where #16 keeps the line editor sane on hosts that don't know `xterm-ghostty` by silently downgrading to `xterm-256color`, this PR makes the host actually understand `xterm-ghostty` so users get full-fidelity Ghostty support over SSH out of the box.

Per your link to https://ghostty.org/docs/help/terminfo.

## What Ghostty's docs recommend

The canonical install command runs on the **local** machine (not the host):

```bash
infocmp -x xterm-ghostty | ssh user@host -- tic -x -
```

That doesn't fit Franklin's install model — `install.sh` runs on the target host (a Pi, a server, etc.), not on the user's daily-driver Mac with Ghostty installed locally. So we can't invoke the official method from inside the install.

## What this PR does

`install.sh` adds a new "Modern terminal terminfo entries" step that:

1. **Skips** if the host already has `xterm-ghostty` (e.g. a Mac where Ghostty is installed locally and registered its terminfo).
2. **Fetches** the upstream `ghostty.terminfo` from the `ghostty-org/ghostty` repo and compiles it into `~/.terminfo` via `tic -x -o ~/.terminfo`. No sudo. Full fidelity.
3. **Falls back to a clear nudge** with the official one-liner when the fetch can't run (no `tic`, no network, etc.):
   ```
   ⎿  For canonical install, run from your local machine:
      infocmp -x xterm-ghostty | ssh user@<this-host> -- tic -x -
   ```
4. The zshrc `TERM` fallback from #16 catches anything that slips through — degraded but functional shell.

## Layered safety

| Layer | What it does | When it kicks in |
|---|---|---|
| `install.sh` fetch + `tic` (this PR) | Full ghostty terminfo on the host | Whenever the install runs and `tic` + network are available |
| zshrc TERM fallback (#16) | Downgrades unknown TERM to xterm-256color | Per shell startup, if terminfo is still unknown |
| Documented official command (warning text) | Manual escape hatch | When the auto-install fails |
| Ghostty's `ssh-terminfo` shell integration (out of scope) | Auto-pushes terminfo on first SSH | When user enables it on the *client* |

## Why fetch from the repo URL instead of the official docs method

The official method needs `infocmp` running on the **client**. Franklin runs on the **host**. The only way to bootstrap `xterm-ghostty` on the host without manual steps is to fetch the source from somewhere — `raw.githubusercontent.com/ghostty-org/ghostty/main/src/terminfo/ghostty.terminfo` is the upstream source-of-truth. It's unofficial as a "remote install" pattern but it's the same .terminfo the official method ships.

## Test plan

- [ ] Fresh Pi (the one that hit the original bug): re-run install (`franklin update` then re-run `install.sh`), verify the new step prints `Ghostty terminfo installed (xterm-ghostty)`. SSH back in from Ghostty, confirm `infocmp xterm-ghostty` succeeds and typing isn't garbled.
- [ ] Same Pi without network access: verify the step warns and prints the official one-liner with the actual hostname expanded.
- [ ] macOS where Ghostty is already installed: verify the step prints "Ghostty terminfo already present, skipping" (no re-install, no clobber).
- [ ] Host where `tic` isn't installed (rare; ncurses-bin missing on a minimal Debian image): verify the warning + nudge.
- [ ] `franklin update` to redeploy install.sh, then `bash install.sh --non-interactive` to verify idempotency.

https://claude.ai/code/session_01L6DH2fz6xtpoKMbvCK9Tks