### PR TITLE
feat(zshrc): advertise COLORTERM=truecolor when TERM fallback triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Truecolor is advertised via `COLORTERM=truecolor`** whenever the zshrc `TERM` fallback kicks in. The fallback only triggers when an unknown (almost always modern) terminal is connecting, and every modern terminal — Ghostty, Kitty, WezTerm, iTerm2, Alacritty — renders 24-bit color escapes natively regardless of terminfo. Apps that check `$COLORTERM` (Starship, bat, nvim, fzf, delta, …) will now emit truecolor sequences in the fallback case instead of quantising to the 256-color palette implied by `TERM=xterm-256color`. Uses `: "${COLORTERM:=truecolor}"` so any value the client actually set (passed through via SSH's `SendEnv`, for instance) is preserved.
+
 ### Added
 
 - **`install.sh` installs Ghostty's terminfo into `~/.terminfo`** (best-effort) so that SSH'ing into a Franklin-managed host from Ghostty gets full-fidelity terminal support out of the box. Uses the upstream terminfo source from `ghostty-org/ghostty` and compiles it via `tic -x -o ~/.terminfo`; no sudo required. If the fetch fails (no network, no `tic`, etc.), the install warns and shows Ghostty's official one-liner from the docs at https://ghostty.org/docs/help/terminfo: `infocmp -x xterm-ghostty | ssh user@host -- tic -x -`. The zshrc `TERM=xterm-256color` fallback (also new in this release) catches anything that slips through. Works alongside the official "ssh-terminfo" Ghostty shell-integration feature, which auto-pushes terminfo on first connect when enabled on the client.

--- a/franklin/templates/zshrc.zsh
+++ b/franklin/templates/zshrc.zsh
@@ -14,8 +14,18 @@ export FRANKLIN_CONFIG="${HOME}/.config/franklin"
 # into a host where ghostty terminfo isn't installed. Falling back to
 # xterm-256color preserves 256-color support and a sane line editor without
 # requiring any per-host setup.
+#
+# When we fall back, also advertise truecolor via COLORTERM (unless the
+# client already set one). The TERM fallback only triggers when an unknown —
+# almost always modern — terminal is connecting, and every modern terminal
+# (Ghostty, Kitty, WezTerm, iTerm2, Alacritty, …) renders 24-bit color
+# escapes natively regardless of terminfo. Apps that check COLORTERM
+# (Starship, bat, nvim, fzf, delta, …) will then still emit truecolor
+# sequences instead of quantising to the 256-color palette implied by TERM.
 if [[ -n "${TERM:-}" ]] && ! infocmp -q "$TERM" >/dev/null 2>&1; then
     export TERM=xterm-256color
+    : "${COLORTERM:=truecolor}"
+    export COLORTERM
 fi
 
 # --- PATH Management ---


### PR DESCRIPTION
## Summary

Follow-up to #16/#17. When the zshrc `TERM` fallback triggers (unknown TERM → `xterm-256color`), we also now export `COLORTERM=truecolor` so apps keep emitting 24-bit color escapes instead of quantizing to the 256 palette.

## Why this helps

`TERM=xterm-256color` tells terminfo-aware apps "256 colors available" — they'll downgrade Starship gradients, `bat` syntax highlighting, `delta` diffs, `nvim` themes to the 256 palette even though the terminal actually rendering the output (Ghostty, Kitty, etc.) handles 24-bit just fine.

Most modern apps check `$COLORTERM` as a parallel capability signal: if it's `truecolor` or `24bit`, emit 24-bit escapes regardless of what terminfo says. So:

- **Before this PR:** Ghostty SSH → Pi → fallback → TERM=xterm-256color, COLORTERM unset → Starship gradients render as 256 approximations.
- **After this PR:** same path → TERM=xterm-256color, COLORTERM=truecolor → Starship gradients render as actual 24-bit on the Ghostty side.

## Why it's safe

The fallback *only* triggers when the client's advertised TERM is unknown to the host's terminfo. In practice, that almost always means a modern terminal (Ghostty, Kitty, WezTerm, iTerm2, Alacritty) is connecting — all of which support truecolor natively. If somehow a non-truecolor-capable client connects with a weird TERM, the worst case is escape sequences render as degraded color, not as visible garbage.

Uses `: "${COLORTERM:=truecolor}"` so we never override a value the client actually pushed (SSH `SendEnv COLORTERM`, for example).

## Diff

```diff
 if [[ -n "${TERM:-}" ]] && ! infocmp -q "$TERM" >/dev/null 2>&1; then
     export TERM=xterm-256color
+    : "${COLORTERM:=truecolor}"
+    export COLORTERM
 fi
```

Three lines of behaviour, a few lines of comment explaining why.

## Test plan

- [ ] Fresh Pi (post-merge, `franklin update` + new shell): verify `echo $COLORTERM` returns `truecolor` in the fallback case.
- [ ] Run `bat` or `starship module` — gradient output should render as true 24-bit on the Ghostty side.
- [ ] SSH from a non-truecolor terminal with known TERM (e.g. plain `xterm`): verify the fallback doesn't fire so `COLORTERM` stays unset.
- [ ] SSH from a client pushing `COLORTERM=truecolor` via SendEnv: verify it stays as the client's value, we don't clobber.

## Interaction with open PRs

Branches off current `main` (pre-#18). Once #18 (release: v2.1.3) merges, this PR will conflict on CHANGELOG's `[Unreleased]` section — easy manual resolve (the truecolor bullet belongs in a fresh `[Unreleased]` above `[2.1.3]` after #18 lands). Happy to handle the rebase.

https://claude.ai/code/session_01L6DH2fz6xtpoKMbvCK9Tks