### PR TITLE
ci: automate tag + GitHub Release on version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,123 @@
+name: Release
+
+# Fires when a release lands on main (i.e. the VERSION file changed). The
+# release PR from CLAUDE.md's playbook bumps VERSION + pyproject.toml +
+# CHANGELOG together, so a VERSION diff vs. the previous main tip is a
+# reliable, merge-style-agnostic signal that this is a release push.
+#
+# This workflow replaces what was previously Steps 3-4 of the manual
+# playbook (tag push + click-to-publish).
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect VERSION change
+        id: detect
+        run: |
+          set -euo pipefail
+          # github.event.before is all-zeros for branch-create events. Fall
+          # back to HEAD~1 in that case so the workflow still does the right
+          # thing on first push.
+          before="${{ github.event.before }}"
+          if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ]; then
+              before="HEAD~1"
+          fi
+          if git diff --quiet "$before" HEAD -- VERSION 2>/dev/null; then
+              echo "VERSION unchanged; this is not a release push."
+              echo "release=false" >> "$GITHUB_OUTPUT"
+              exit 0
+          fi
+          new_v="$(tr -d '[:space:]' < VERSION)"
+          if ! [[ "$new_v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::VERSION ($new_v) is not a valid X.Y.Z semver"
+              exit 1
+          fi
+          echo "VERSION changed; preparing release v$new_v"
+          echo "release=true" >> "$GITHUB_OUTPUT"
+          echo "version=$new_v" >> "$GITHUB_OUTPUT"
+          echo "tag=v$new_v" >> "$GITHUB_OUTPUT"
+
+      - name: Verify pyproject.toml agrees with VERSION
+        if: steps.detect.outputs.release == 'true'
+        run: |
+          set -euo pipefail
+          v="${{ steps.detect.outputs.version }}"
+          py_v="$(grep -m1 '^version = ' franklin/pyproject.toml | sed 's/^version = "\(.*\)"$/\1/')"
+          if [ "$v" != "$py_v" ]; then
+              echo "::error::pyproject.toml version ($py_v) does not match VERSION ($v)"
+              exit 1
+          fi
+
+      - name: Skip if tag already exists on origin
+        if: steps.detect.outputs.release == 'true'
+        id: gate
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ steps.detect.outputs.tag }}" >/dev/null 2>&1; then
+              echo "Tag ${{ steps.detect.outputs.tag }} already exists on origin — nothing to do."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract changelog section
+        if: steps.detect.outputs.release == 'true' && steps.gate.outputs.skip != 'true'
+        id: notes
+        run: |
+          set -euo pipefail
+          v="${{ steps.detect.outputs.version }}"
+          notes_file="$(mktemp)"
+          # Print everything from "## [vX.Y.Z]" through (but not including)
+          # the next top-level "## [" header.
+          awk -v ver="$v" '
+              /^## \[/ {
+                  if (in_section) { exit }
+                  if ($0 ~ "^## \\[" ver "\\]") { in_section = 1; next }
+              }
+              in_section { print }
+          ' CHANGELOG.md > "$notes_file"
+          if ! [ -s "$notes_file" ]; then
+              echo "::error::Could not find '## [$v]' section in CHANGELOG.md"
+              exit 1
+          fi
+          {
+              cat "$notes_file"
+              echo ""
+              echo "---"
+              echo "Full changelog: https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md"
+          } > "${notes_file}.full"
+          mv "${notes_file}.full" "$notes_file"
+          echo "notes_file=$notes_file" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        if: steps.detect.outputs.release == 'true' && steps.gate.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.detect.outputs.tag }}" -m "Franklin ${{ steps.detect.outputs.tag }}"
+          git push origin "${{ steps.detect.outputs.tag }}"
+
+      - name: Publish GitHub Release
+        if: steps.detect.outputs.release == 'true' && steps.gate.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release create "${{ steps.detect.outputs.tag }}" \
+              --title  "Franklin ${{ steps.detect.outputs.tag }}" \
+              --notes-file "${{ steps.notes.outputs.notes_file }}" \
+              --target "${{ github.sha }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Scopes: `cli`, `install`, `update`, `ui`, `motd`, `config`
 
 ## Release Workflow
 
-When the user asks to cut a release — any phrasing ("cut a release", "ship v2.1.3", "tag and publish") — the assistant runs the full playbook below. The user's only manual steps are to merge the PR and (until the git-proxy blocker is lifted) push the tag and click Publish. The assistant never hands off changelog curation, version math, or SHA lookup.
+When the user asks to cut a release — any phrasing ("cut a release", "ship v2.1.3", "tag and publish") — the assistant runs the full playbook below. Tagging and publishing the GitHub Release are automated by `.github/workflows/release.yml`; the only manual step is merging the release PR.
 
 ### Step 1 — Agent: open the release PR
 
@@ -136,48 +136,37 @@ When the user asks to cut a release — any phrasing ("cut a release", "ship v2.
    - `VERSION` → `X.Y.Z`
    - `franklin/pyproject.toml` → `version = "X.Y.Z"`
    - `CHANGELOG.md` → promote `[Unreleased]` to `[X.Y.Z] - <today>` and leave a fresh empty `[Unreleased]` block above it.
-4. Commit with `release: vX.Y.Z` and a body summarising the changes since the prior tag (grouped by PR).
+4. Commit with subject `release: vX.Y.Z` and a body summarising the changes since the prior tag (grouped by PR).
 5. Push and open the PR (title: `release: vX.Y.Z`).
 
 ### Step 2 — User: merge the release PR
 
-Standard "merge commit" method (matches every prior Franklin release).
+Any merge style works (merge-commit, squash, rebase). The workflow detects the release by `VERSION` file change, not by commit subject.
 
-### Step 3 — Agent: tag and prepare the publish kit
+### Step 3 — Workflow: tag and publish (automatic)
 
-After the merge webhook fires, the assistant:
+`.github/workflows/release.yml` fires on every push to `main` and detects releases by diffing `VERSION` against the previous main tip. When `VERSION` changes, it:
 
-1. `git checkout main && git pull origin main` to fast-forward locally.
-2. `git tag -a vX.Y.Z <merge-sha> -m "Franklin vX.Y.Z"` on the merge commit.
-3. Attempts `git push origin vX.Y.Z`. **This currently 403s** because the localhost git proxy filters `refs/tags/*` pushes (see "Known blocker" below).
+1. Validates the new `VERSION` is a `X.Y.Z` semver and that `franklin/pyproject.toml` agrees.
+2. Checks that `vX.Y.Z` doesn't already exist on `origin` (idempotent — re-running on the same merge SHA is a no-op).
+3. Extracts the `## [X.Y.Z] - <date>` section from `CHANGELOG.md` as the release body, appending a link back to the full file.
+4. Creates and pushes the annotated tag `vX.Y.Z` on the merge SHA (via `GITHUB_TOKEN`, so the localhost git-proxy tag-push 403 is bypassed entirely).
+5. Publishes the GitHub Release as `Franklin vX.Y.Z`.
 
-**Regardless of whether the tag push succeeded**, the assistant posts a single "publish kit" message with:
+The agent should confirm the workflow succeeded by checking `Actions → Release` for the new run, then end the release task. **No publish-kit message is needed.**
 
-- The merge SHA.
-- A ready-to-run snippet for the user's local machine:
-  ```bash
-  git fetch origin
-  git tag -a vX.Y.Z <merge-sha> -m "Franklin vX.Y.Z"
-  git push origin vX.Y.Z
-  ```
-- The direct-click URL: `https://github.com/jeremyfuksa/franklin/releases/new?tag=vX.Y.Z`
-- The release **title**: `Franklin vX.Y.Z`.
-- The release **body**: ready-to-paste Markdown pulled from the new CHANGELOG section, reorganised into a short "Highlights" summary at the top with a link back to the CHANGELOG for the full detail block.
+### Manual fallback
 
-### Step 4 — User: push the tag and publish
+If the workflow fails (mismatched versions, missing CHANGELOG section, etc.):
 
-1. Run the three-line `git` snippet from the publish kit.
-2. Open the URL from the publish kit.
-3. Paste title (if not already pre-filled) and body.
-4. Click **Publish release**.
-
-### Known blocker: tag push 403
-
-The localhost git proxy at `http://local_proxy@127.0.0.1:<port>/…` currently allows branch pushes but rejects `refs/tags/*` with HTTP 403. Once its ref-allowlist is relaxed to include tags, Step 3's push will succeed and the agent can (a) push the tag directly, (b) call `mcp__github__create_release` (once that tool is exposed by the MCP server's `repos` toolset), and skip the user's tag-push+click loop entirely.
+1. `git checkout main && git pull origin main`
+2. `git tag -a vX.Y.Z <merge-sha> -m "Franklin vX.Y.Z"`
+3. `git push origin vX.Y.Z` (the localhost git proxy currently 403s tag pushes, so this step usually has to run on the user's machine)
+4. Open `https://github.com/jeremyfuksa/franklin/releases/new?tag=vX.Y.Z`, paste the CHANGELOG section as the body, set the title to `Franklin vX.Y.Z`, and click **Publish release**.
 
 ### Cross-project note
 
-This playbook lives in this repo's `CLAUDE.md`, so it applies to Franklin only. To get the same behaviour in another project, mirror this section into that project's `CLAUDE.md` (or add it to `~/.claude/CLAUDE.md` for every session, repo-agnostic).
+This playbook lives in this repo's `CLAUDE.md`, so it applies to Franklin only. To get the same behaviour in another project, mirror this section into that project's `CLAUDE.md` (or add it to `~/.claude/CLAUDE.md` for every session, repo-agnostic) and copy `.github/workflows/release.yml`.
 
 ## Key Principles
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` to automate Steps 3–4 of the release playbook (tag push + click-to-publish). Detects releases by **`VERSION` file change** rather than commit subject — merge-style-agnostic, so it works with merge-commits (the project's current default), squash, or rebase.

When `VERSION` changes on `main`, the workflow:

1. Validates the new `VERSION` is `X.Y.Z` semver and `franklin/pyproject.toml` agrees.
2. Skips if `vX.Y.Z` already exists on `origin` (idempotent — re-runs on the same SHA are no-ops).
3. Extracts the matching `## [X.Y.Z]` section from `CHANGELOG.md` as the release body, with a link back to the full file.
4. Creates + pushes the annotated tag `vX.Y.Z` on the merge SHA. Uses `GITHUB_TOKEN`, so the localhost git-proxy tag-push 403 from CLAUDE.md is bypassed entirely.
5. Publishes the GitHub Release as `Franklin vX.Y.Z`.

`CLAUDE.md` updated to reflect the new flow and to keep a manual fallback for the failure case.

## Why VERSION-change detection, not commit-subject matching
First draft of this workflow gated on `startsWith(head_commit.message, 'release: v')`. But this project merges release PRs with the default merge-commit style — the resulting head commit subject is `Merge pull request #N from …/claude/release-vX.Y.Z`, not `release: vX.Y.Z`. The gate would never fire. VERSION-change detection sidesteps the merge-style question entirely.

## Test plan
- [x] `awk` changelog extractor sanity-tested against current `CHANGELOG.md` for `2.1.3` and a nonexistent version
- [x] `actionlint`-compatible YAML structure (will surface in CI if syntax broken)
- [ ] **End-to-end verification will happen on the next release.** The first real run is the next `release: vX.Y.Z` PR — if it misfires, fall back to the manual flow documented in `CLAUDE.md`.

## Caveats
- The default `GITHUB_TOKEN` does push tags and create releases — no PAT needed.
- The workflow's tag push triggers a `push: tags: 'v*'` event, but no tag-triggered workflow exists in this repo, so no infinite-loop risk.
- If someone bumps `VERSION` outside the release playbook (e.g., a botched commit), the workflow will fail at the changelog-extract step rather than create a spurious release.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VzYrQBJkVLUF2t5c2pRvia)_