### PR TITLE
fix(motd): adaptive unit so sub-1GiB RAM doesn't render as 0G/0G

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **MOTD RAM/disk no longer collapses to `0G/0G` on sub-1GiB devices.** Both `get_memory_stats()` and `get_disk_stats()` formatted gigabytes with `{:.0f}`, so a Raspberry Pi Zero 2W (512MB RAM) rounded both used and total to `0G`. A new `format_bytes_pair()` helper picks an adaptive unit — sub-1GiB totals render in `M`, multi-GiB totals keep the existing `G` format — so the Pi Zero now shows e.g. `RAM 200M/512M` and normal machines remain unchanged.
+
 ## [2.1.4] - 2026-05-12
 
 ### Fixed

--- a/franklin/src/lib/motd.py
+++ b/franklin/src/lib/motd.py
@@ -157,16 +157,26 @@ def create_progress_bar(percent: float, width: int = 10) -> str:
     return f"|{'█' * filled}{'░' * empty}|"
 
 
+def format_bytes_pair(used: float, total: float) -> Tuple[str, str]:
+    """Format a used/total byte pair with a consistent adaptive unit.
+
+    Sub-1GiB totals render in MiB so low-memory devices (e.g. Pi Zero 2W
+    with 512MB RAM) don't collapse to "0G/0G" after integer rounding.
+    """
+    if total < 1024**3:
+        return f"{used / (1024**2):.0f}M", f"{total / (1024**2):.0f}M"
+    return f"{used / (1024**3):.0f}G", f"{total / (1024**3):.0f}G"
+
+
 def get_disk_stats() -> Tuple[str, float, str, str]:
     """Get disk usage statistics."""
     try:
         disk = shutil.disk_usage("/")
-        total_gb = disk.total / (1024**3)
-        used_gb = disk.used / (1024**3)
         percent = (disk.used / disk.total) * 100
+        used, total = format_bytes_pair(disk.used, disk.total)
 
         bar = create_progress_bar(percent)
-        return bar, percent, f"{used_gb:.0f}G", f"{total_gb:.0f}G"
+        return bar, percent, used, total
     except (OSError, ZeroDivisionError):
         return "|??????????|", 0, "??", "??"
 
@@ -175,9 +185,7 @@ def get_memory_stats() -> Tuple[str, str]:
     """Get memory usage statistics."""
     try:
         mem = psutil.virtual_memory()
-        used_gb = mem.used / (1024**3)
-        total_gb = mem.total / (1024**3)
-        return f"{used_gb:.0f}G", f"{total_gb:.0f}G"
+        return format_bytes_pair(mem.used, mem.total)
     except (psutil.Error, OSError):
         return "??", "??"
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -241,12 +241,34 @@ class TestMOTD:
     def test_get_disk_stats_returns_tuple(self):
         """Test that disk stats returns expected format."""
         from lib.motd import get_disk_stats
-        
+
         bar, percent, used, total = get_disk_stats()
         assert isinstance(bar, str)
         assert isinstance(percent, (int, float))
         assert isinstance(used, str)
         assert isinstance(total, str)
+
+    def test_format_bytes_pair_sub_gigabyte_uses_megabytes(self):
+        """Sub-1GiB totals must render in M, not collapse to '0G/0G'.
+
+        Regression test for the Pi Zero 2W (512MB RAM) case: integer-formatted
+        gigabytes rounded both used and total to 0G, making the MOTD show
+        "RAM 0G/0G".
+        """
+        from lib.motd import format_bytes_pair
+
+        # Pi Zero 2W: ~200MiB used out of 512MiB total
+        used, total = format_bytes_pair(200 * 1024**2, 512 * 1024**2)
+        assert used.endswith("M") and total.endswith("M")
+        assert used != "0M" and total != "0M"
+
+    def test_format_bytes_pair_gigabyte_range_uses_gigabytes(self):
+        """Multi-GiB totals keep the existing G-suffixed format."""
+        from lib.motd import format_bytes_pair
+
+        used, total = format_bytes_pair(8 * 1024**3, 16 * 1024**3)
+        assert used == "8G"
+        assert total == "16G"
 
     def test_create_progress_bar(self):
         """Test progress bar generation."""


### PR DESCRIPTION
## Summary

- On a Raspberry Pi Zero 2W (512MB RAM), the MOTD rendered `RAM 0G/0G` because both used and total memory rounded to 0 under the `{:.0f}G` format. Disk stats had the same shape and would have hit the same edge on tiny SD cards.
- Added `format_bytes_pair()` in `franklin/src/lib/motd.py` that picks the unit from the total: sub-1GiB totals render in `M`, multi-GiB totals keep the existing `G` format. Wired both `get_memory_stats()` and `get_disk_stats()` through it.
- Added two regression tests covering the sub-1GiB (Pi Zero) and multi-GiB (normal machine) branches, plus a CHANGELOG entry under `[Unreleased]`.

## Test plan

- [x] `pytest test/test_cli.py` — all 31 tests pass, including the two new `format_bytes_pair` tests
- [ ] Manual verification on a Pi Zero 2W: confirm MOTD shows e.g. `RAM 200M/512M` instead of `RAM 0G/0G`
- [ ] Spot-check MOTD on a normal-RAM machine to confirm output is unchanged (`RAM 8G/16G` style)

https://claude.ai/code/session_01PCED7shiTpxP7kinrkJod7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCED7shiTpxP7kinrkJod7)_