### PR TITLE
fix(config): raise starship scan_timeout to 500ms for slow ARM SBCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - **MOTD RAM/disk no longer collapses to `0G/0G` on sub-1GiB devices.** Both `get_memory_stats()` and `get_disk_stats()` formatted gigabytes with `{:.0f}`, so a Raspberry Pi Zero 2W (512MB RAM) rounded both used and total to `0G`. A new `format_bytes_pair()` helper picks an adaptive unit — sub-1GiB totals render in `M`, multi-GiB totals keep the existing `G` format — so the Pi Zero now shows e.g. `RAM 200M/512M` and normal machines remain unchanged.
+- **Starship no longer warns on slow ARM SBCs.** The default `scan_timeout` of 30ms was too tight for a Pi Zero 2W's single-core ARM CPU, so every prompt printed `Scanning current directory timed out`. `franklin/config/starship.toml` now sets `scan_timeout = 500`, which comfortably covers slow devices while still aborting on truly stuck filesystems. Fast machines are unaffected — the setting is a ceiling, not a delay.
 
 ## [2.1.4] - 2026-05-12
 

--- a/franklin/config/starship.toml
+++ b/franklin/config/starship.toml
@@ -26,6 +26,12 @@ $character"""
 # Disable scanning for new versions
 add_newline = false
 
+# Default is 30ms — too tight for slow ARM SBCs (e.g. Pi Zero 2W) where
+# scanning a moderately-sized repo races past the deadline and starship
+# prints a runtime warning on every prompt. 500ms is generous enough to
+# cover those devices while still aborting on truly stuck filesystems.
+scan_timeout = 500
+
 [character]
 success_symbol = "[❯](bold green)"
 error_symbol = "[❯](bold red)"


### PR DESCRIPTION
## Summary

- A Pi Zero 2W's single-core Cortex-A53 can't finish a moderately-sized git scan within starship's 30ms default, so every prompt prints `[WARN] - (starship::context): Scanning current directory timed out`.
- Bump `scan_timeout` to 500ms in `franklin/config/starship.toml` — generous enough to cover slow ARM SBCs while still aborting on truly stuck filesystems. The setting is a ceiling, not a delay, so fast machines are unaffected.
- CHANGELOG entry added under `[Unreleased]`.

## Test plan

- [ ] Manual verification on a Pi Zero 2W: confirm the `Scanning current directory timed out` warning no longer appears at prompt render
- [ ] Spot-check on a normal-speed machine to confirm prompt latency is unchanged

https://claude.ai/code/session_01PCED7shiTpxP7kinrkJod7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCED7shiTpxP7kinrkJod7)_